### PR TITLE
Make backup-loop.sh handle errors better and be more modular

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,60 @@
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: Linting and sanity tests
+      name: Lint script with shellcheck
+      script:
+        - "readarray -t shell_scripts < <(find * -name '*.sh' -a ! -path '*/.git/*')"
+        - echo checking "${shell_scripts[@]}"
+        - shellcheck "${shell_scripts[@]}"
+    - name: Lint dockerfile
+      # DL3006 Always tag the version of an image explicitly
+      # DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
+      script: >- 
+        docker run --rm -i hadolint/hadolint hadolint
+        --ignore DL3018
+        --ignore DL3006
+        - < Dockerfile
+    - name: Test simple backup and exclusion scenario
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y
+          tree
+      env:
+        SRC_DIR: /tmp/source
+        DEST_DIR: /tmp/dest
+        EXTRACT_DIR: /tmp/extract
+        BACKUP_INTERVAL: 0
+        INITIAL_DELAY: 5s
+        EXCLUDES: '*.jar,exclude_dir'
+        RCON_PATH: /usr/bin/rcon-cli
+        PRUNE_BACKUPS_DAYS: 3
+      script:
+        - mkdir -p "${SRC_DIR}/"{in,ex}clude_dir "${DEST_DIR}" "${EXTRACT_DIR}"
+        - touch "${SRC_DIR}/"{backup_me.{1,2}.json,exclude_me.jar}
+        - touch "${SRC_DIR}/include_dir/"{backup_me.{1,2}.json,exclude_me.jar}
+        - touch "${SRC_DIR}/exclude_dir/"exclude_me.{1,2}.{json,jar}
+        - tree "${SRC_DIR}"
+        - touch -d "$(( PRUNE_BACKUPS_DAYS + 2 )) days ago" "${DEST_DIR}/fake_backup_that_should_be_deleted.tgz"
+        - ls -al "${DEST_DIR}"
+        - docker build -t testimg .
+        - echo -e '#!/bin/bash\ntrue' > rcon-cli && chmod +x rcon-cli
+        - timeout 50 docker run --rm 
+          --env SRC_DIR
+          --env DEST_DIR
+          --env BACKUP_INTERVAL
+          --env INITIAL_DELAY
+          --env EXCLUDES
+          --env PRUNE_BACKUPS_DAYS
+          --mount "type=bind,src=${SRC_DIR},dst=${SRC_DIR}"
+          --mount "type=bind,src=${DEST_DIR},dst=${DEST_DIR}"
+          --mount "type=bind,src=$(pwd)/rcon-cli,dst=${RCON_PATH}"
+          testimg
+        - tree "${DEST_DIR}"
+        - tar -xzf "${DEST_DIR}/"*.tgz -C "${EXTRACT_DIR}"
+        - tree "${EXTRACT_DIR}"
+        - '[ -z "$(find "${EXTRACT_DIR}" -name "exclude_*" -print -quit)" ]'
+        - '[ 4 -eq "$(find "${EXTRACT_DIR}" -name "backup_me*" -print | wc -l)" ]'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,29 @@
-FROM alpine
+FROM alpine AS builder
 
-RUN apk -U add unzip bash
-
-ARG RCLONE_VERSION=1.46
 ARG RCON_CLI_VERSION=1.4.4
-
-ADD https://github.com/ncw/rclone/releases/download/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip /tmp/rclone.zip
-
-RUN unzip /tmp/rclone.zip -d /opt && \
-    ln -s /opt/rclone-v${RCLONE_VERSION}-linux-amd64/rclone /usr/bin && \
-    rm /tmp/rclone.zip
 
 ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VERSION}/rcon-cli_${RCON_CLI_VERSION}_linux_amd64.tar.gz /tmp/rcon-cli.tgz
 
 RUN mkdir -p /opt/rcon-cli && \
     tar x -f /tmp/rcon-cli.tgz -C /opt/rcon-cli && \
-    ln -s /opt/rcon-cli/rcon-cli /usr/bin && \
     rm /tmp/rcon-cli.tgz
+
+
+
+FROM alpine
+
+RUN apk -U --no-cache add \
+    bash \
+    coreutils \
+    unzip
+
+COPY --from=builder /opt/rcon-cli/rcon-cli /opt/rcon-cli/rcon-cli
+
+RUN ln -s /opt/rcon-cli/rcon-cli /usr/bin
 
 ENTRYPOINT ["/opt/backup-loop.sh"]
 
 VOLUME ["/data", "/backups"]
-
-ENV SRC_DIR=/data \
-    DEST_DIR=/backups \
-    BACKUP_NAME=world \
-    INITIAL_DELAY=120 \
-    INTERVAL_SEC=86400 \
-    PRUNE_BACKUPS_DAYS=7 \
-    TYPE=VANILLA \
-    LEVEL=world \
-    RCON_PORT=25575 \
-    RCON_PASSWORD=minecraft
 
 COPY backup-loop.sh /opt/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/itzg/mc-backup.svg)](https://hub.docker.com/r/itzg/mc-backup)
+[![Build Status](https://travis-ci.org/itzg/docker-mc-backup.svg?branch=master)](https://travis-ci.org/itzg/docker-mc-backup)
 
 Provides a side-car container to backup itzg/minecraft-server world data.
 
@@ -7,13 +8,27 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `SRC_DIR`=/data
 - `DEST_DIR`=/backups
 - `BACKUP_NAME`=world
-- `INITIAL_DELAY`=120
-- `INTERVAL_SEC`=86400
-- `TYPE`=VANILLA
-- `LEVEL`=world
+- `INITIAL_DELAY`=2m
+- `BACKUP_INTERVAL`=24h
+- `PRUNE_BACKUPS_DAYS`=7
 - `RCON_PORT`=25575
 - `RCON_PASSWORD`=minecraft
-    
+- `EXCLUDES`=\*.jar,cache,logs
+
+If `PRUNE_BACKUP_DAYS` is set to a positive number, it'll delete old `.tgz` backup files from `DEST_DIR`. By default deletes backups older than a week.
+
+If `BACKUP_INTERVAL` is set to 0 or smaller, script will run once and exit.
+
+Both `INITIAL_DELAY` and `BACKUP_INTERVAL` accept times in `sleep` format: `NUMBER[SUFFIX] NUMBER[SUFFIX] ...`.
+SUFFIX may be 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+
+Examples:
+- `BACKUP_INTERVAL`="1.5d" -> backup every one and a half days (36 hours)
+- `BACKUP_INTERVAL`="2h 30m" -> backup every two and a half hours
+- `INITIAL_DELAY`="120" -> wait 2 minutes before starting
+
+`EXCLUDES` is a comma-separated list of glob(3) patterns to exclude from backups. By default excludes all jar files (plugins, server files), logs folder and cache (used by i.e. PaperMC server).
+
 ## Volumes
 
 - `/data` :
@@ -43,8 +58,8 @@ containers:
     securityContext:
       runAsUser: 1000
     env:
-      - name: INTERVAL_SEC
-        value: "3600"
+      - name: BACKUP_INTERVAL
+        value: "2h 30m"
     volumeMounts:
       - mountPath: /data
         name: data

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -1,69 +1,143 @@
 #!/bin/bash
 
+set -euo pipefail
+
+readonly backup_extension="tgz"
+: "${SRC_DIR:=/data}"
+: "${DEST_DIR:=/backups}"
+: "${BACKUP_NAME:=world}"
+: "${INITIAL_DELAY:=2m}"
+: "${BACKUP_INTERVAL:=${INTERVAL_SEC:-24h}}"
+: "${PRUNE_BACKUPS_DAYS:=7}"
+: "${RCON_PORT:=25575}"
+: "${RCON_PASSWORD:=minecraft}"
+: "${EXCLUDES:=*.jar,cache,logs}" # Comma separated list of glob(3) patterns
+
+export RCON_PORT
+export RCON_PASSWORD
+
 log() {
-  level=$1
+  if [ "$#" -lt 1 ]; then
+    echo "Wrong number of arguments passed to log function" >&2
+    return 1
+  fi
+  local level="${1}"
   shift
-  echo "$(date -Iseconds) ${level} $*"
+  (
+    # If any arguments are passed besides log level
+    if [ "$#" -ge 1 ]; then
+      # then use them as log message(s)
+      <<<"${*}" cat -
+    else
+      # otherwise read log messages from standard input
+      cat -
+    fi
+  ) | awk -v level="${level}" '{ printf("%s %s %s\n", strftime("%FT%T%z"), level, $0); fflush(); }'
 }
 
-backupSet=${BACKUP_SET}
-excludes="--exclude '*.jar'"
+find_old_backups() {
+  find "${DEST_DIR}" -maxdepth 1 -name "*.${backup_extension}" -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
+}
 
-case $TYPE in
-  FTB|CURSEFORGE)
-    cd ${SRC_DIR}/FeedTheBeast
-    ;;
-  *)
-    cd ${SRC_DIR}
-    ;;
-esac
+retry() {
+  if [ "$#" -lt 3 ]; then
+    log ERROR "Wrong number of arguments passed to retry function"
+    return 1
+  fi
 
-backupSet="${backupSet} ${LEVEL}"
-backupSet="${backupSet} $(find . -maxdepth 1 -name '*.properties' -o -name '*.yml' -o -name '*.yaml' -o -name '*.json')"
+  # How many times should we retry?
+  # Value smaller than zero means infinitely
+  local retries="${1}"
+  # Time to sleep between retries
+  local interval="${2}"
+  readonly retries interval
+  shift 2
 
-if [ -d plugins ]; then
-  backupSet="${backupSet} plugins"
+  if (( retries < 0 )); then
+    local retries_msg="infinite"
+  else
+    local retries_msg="${retries}"
+  fi
+
+  local i=-1 # -1 since we will increment it before printing
+  while (( retries >= ++i )) || [ "${retries_msg}" != "${retries}" ]; do
+    # Send SIGINT after 5 minutes. If it doesn't shut down in 30 seconds, kill it.
+    if output="$(timeout --signal=SIGINT --kill-after=30s 5m "${@}" 2>&1 | tr '\n' '\t')"; then
+      log INFO "Command executed successfully ${*}"
+      return 0
+    else
+      log ERROR "Unable to execute ${*} - try ${i}/${retries_msg}. Retrying in ${interval}"
+      if [ -n "${output}" ]; then
+        log ERROR "Failure reason: ${output}"
+      fi
+    fi
+    # shellcheck disable=SC2086
+    sleep ${interval}
+  done
+  return 2
+}
+
+if [ -n "${INTERVAL_SEC:-}" ]; then
+  log WARN 'INTERVAL_SEC is deprecated. Use BACKUP_INTERVAL instead'
 fi
 
-log INFO "waiting for rcon readiness..."
-while true; do
-  rcon-cli save-on >& /dev/null && break
+# We unfortunately can't use a here-string, as it inserts new line at the end
+readarray -td, excludes_patterns < <(printf '%s' "${EXCLUDES}")
 
-  sleep 10
+excludes=()
+for pattern in "${excludes_patterns[@]}"; do
+  excludes+=(--exclude "${pattern}")
 done
-log INFO "waiting initial delay of ${INITIAL_DELAY} seconds..."
+
+
+log INFO "waiting initial delay of ${INITIAL_DELAY}..."
+# shellcheck disable=SC2086
 sleep ${INITIAL_DELAY}
+
+log INFO "waiting for rcon readiness..."
+# 20 times, 10 second delay
+retry 20 10s rcon-cli save-on
+
 
 while true; do
   ts=$(date -u +"%Y%m%d-%H%M%S")
 
-  rcon-cli save-off
-  if [ $? = 0 ]; then
+  if retry 5 10s rcon-cli save-off; then
+    # No matter what we were doing, from now on if the script crashes
+    # or gets shut down, we want to make sure saving is on
+    trap 'retry 5 5s rcon-cli save-on' EXIT
 
-    rcon-cli save-all
-    if [ $? = 0 ]; then
+    retry 5 10s rcon-cli save-all
+    outFile="${DEST_DIR}/${BACKUP_NAME}-${ts}.${backup_extension}"
+    log INFO "backing up content in ${SRC_DIR} to ${outFile}"
 
-      outFile="${DEST_DIR}/${BACKUP_NAME}-${ts}.tgz"
-      log INFO "backing up content in $(pwd) to ${outFile}"
-      tar cz -f ${outFile} ${backupSet} ${excludes}
-      if [ $? != 0 ]; then
-        log ERROR "backup failed"
-      else
-        log INFO "successfully backed up"
-      fi
-
+    # shellcheck disable=SC2086
+    if tar "${excludes[@]}" -czf "${outFile}" -C "${SRC_DIR}" .; then
+      log INFO "successfully backed up"
+    else
+      log ERROR "backup failed"
     fi
 
-    rcon-cli save-on
+    retry 20 10s rcon-cli save-on
+    # Remove our exit trap now
+    trap EXIT
   else
-    log ERROR "rcon save-off command failed"
+    log ERROR "Unable to turn saving off. Is the server running?"
+    exit 1
   fi
 
-  if (( ${PRUNE_BACKUPS_DAYS} > 0 )); then
+  if (( PRUNE_BACKUPS_DAYS > 0 )) && [ -n "$(find_old_backups -print -quit)" ]; then
     log INFO "pruning backup files older than ${PRUNE_BACKUPS_DAYS} days"
-    find ${DEST_DIR} -mtime +${PRUNE_BACKUPS_DAYS} -delete
+    find_old_backups -print -delete | log INFO
   fi
 
-  log INFO "sleeping ${INTERVAL_SEC} seconds..."
-  sleep ${INTERVAL_SEC}
+  # If BACKUP_INTERVAL is not a valid number (i.e. 24h), we want to sleep.
+  # Only raw numeric value <= 0 will break
+  if (( BACKUP_INTERVAL <= 0 )) &>/dev/null; then
+    break
+  else
+    log INFO "sleeping ${BACKUP_INTERVAL}..."
+    # shellcheck disable=SC2086
+    sleep ${BACKUP_INTERVAL}
+  fi
 done

--- a/test-deploy.yaml
+++ b/test-deploy.yaml
@@ -31,7 +31,7 @@ spec:
           securityContext:
             runAsUser: 1000
           env:
-            - name: INTERVAL_SEC
+            - name: BACKUP_INTERVAL
               value: "60"
             - name: INITIAL_DELAY
               value: "10"


### PR DESCRIPTION
1. Move ENV definition from Dockerfile to the script - allows using it as a standalone.
2. Make it fail on any unhandled error encountered - makes sure there's no errors we were ignoring, that could cause errors backup up.

TODO:
1. (fixed / no longer applies) Use arrays in place of implicit word splitting - in case people use whitespace in directory names. :disappointed: 
2. (done) Handle "EXCLUDES" better - don't require `--exclude` flag to be provided as part of it.
3. Make `log` filter messages - don't log messages which `level` is lower than `LOG_LEVEL`