### PR TITLE
Optionally create a symlink to the latest backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `RCON_PORT`=25575
 - `RCON_PASSWORD`=minecraft
 - `EXCLUDES`=\*.jar,cache,logs
+- `LINK_LATEST`=false
 
 If `PRUNE_BACKUP_DAYS` is set to a positive number, it'll delete old `.tgz` backup files from `DEST_DIR`. By default deletes backups older than a week.
 
@@ -28,6 +29,8 @@ Examples:
 - `INITIAL_DELAY`="120" -> wait 2 minutes before starting
 
 `EXCLUDES` is a comma-separated list of glob(3) patterns to exclude from backups. By default excludes all jar files (plugins, server files), logs folder and cache (used by i.e. PaperMC server).
+
+`LINK_LATEST` is a true/false flag that creates a symbolic link to the latest backup.
 
 ## Volumes
 

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -12,6 +12,7 @@ readonly backup_extension="tgz"
 : "${RCON_PORT:=25575}"
 : "${RCON_PASSWORD:=minecraft}"
 : "${EXCLUDES:=*.jar,cache,logs}" # Comma separated list of glob(3) patterns
+: "${LINK_LATEST:=false}"
 
 export RCON_PORT
 export RCON_PASSWORD
@@ -114,6 +115,9 @@ while true; do
     # shellcheck disable=SC2086
     if tar "${excludes[@]}" -czf "${outFile}" -C "${SRC_DIR}" .; then
       log INFO "successfully backed up"
+      if [ "${LINK_LATEST^^}" == "TRUE" ]; then
+        ln -sf "${BACKUP_NAME}-${ts}.${backup_extension}" "${DEST_DIR}/latest.${backup_extension}"
+      fi
     else
       log ERROR "backup failed"
     fi


### PR DESCRIPTION
This is a small/niche change to have an up to date symbolic link to point to the latest backup.

I'm using this for syncing the latest backup offsite at a regular interval.