### PR TITLE
Add rclone to dockerfile, to unlock restic rclone options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**
+!backup-loop.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+_common_env: &_common_env
+  SRC_DIR: /tmp/source
+  DEST_DIR: /tmp/dest
+  BACKUP_INTERVAL: 0
+  EXCLUDES: '*.jar,exclude_dir'
+  RCON_PATH: /usr/bin/rcon-cli
+  DEBUG: true
+
 services:
   - docker
 
@@ -15,13 +23,9 @@ jobs:
           tree
           coreutils
       env:
-        SRC_DIR: /tmp/source
-        DEST_DIR: /tmp/dest
+        <<: *_common_env
         EXTRACT_DIR: /tmp/extract
-        BACKUP_INTERVAL: 0
         INITIAL_DELAY: 5s
-        EXCLUDES: '*.jar,exclude_dir'
-        RCON_PATH: /usr/bin/rcon-cli
         PRUNE_BACKUPS_DAYS: 3
       script: bash ./tests/test.simple.tar.sh
     - name: Test restic handling
@@ -31,12 +35,20 @@ jobs:
           tree
           coreutils
       env:
-        SRC_DIR: /tmp/source
-        DEST_DIR: /tmp/dest
+        <<: *_common_env
         RESTIC_REPOSITORY: /tmp/dest
-        BACKUP_INTERVAL: 0
         INITIAL_DELAY: 0s
-        EXCLUDES: '*.jar,exclude_dir'
-        RCON_PATH: /usr/bin/rcon-cli
+        RESTIC_PASSWORD: 1234
+      script: bash ./tests/test.simple.restic.sh
+    - name: Test restic rclone handling
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get install -y
+          tree
+          coreutils
+      env:
+        <<: *_common_env
+        RESTIC_REPOSITORY: rclone:/tmp/dest
+        INITIAL_DELAY: 0s
         RESTIC_PASSWORD: 1234
       script: bash ./tests/test.simple.restic.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,39 @@
 FROM alpine AS builder
 
+RUN mkdir -p /opt
+
 ARG IMAGE_ARCH=amd64
 
 ARG RCON_CLI_VERSION=1.4.4
 
 ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VERSION}/rcon-cli_${RCON_CLI_VERSION}_linux_${IMAGE_ARCH}.tar.gz /tmp/rcon-cli.tar.gz
 
-RUN mkdir -p /opt/rcon-cli && \
-    tar x -f /tmp/rcon-cli.tar.gz -C /opt/rcon-cli && \
-    rm /tmp/rcon-cli.tar.gz
+RUN tar x -f /tmp/rcon-cli.tar.gz -C /opt/ && \
+    chmod +x /opt/rcon-cli
 
 ARG RESTIC_VERSION=0.9.5
 
 ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${IMAGE_ARCH}.bz2 /tmp/restic.bz2
 
 RUN bunzip2 /tmp/restic.bz2 && \
-    mv /tmp/restic /opt/restic
+    mv /tmp/restic /opt/restic && \
+    chmod +x /opt/restic
 
 ARG DEMOTER_VERSION=0.1.0
 
 ADD https://github.com/itzg/entrypoint-demoter/releases/download/${DEMOTER_VERSION}/entrypoint-demoter_${DEMOTER_VERSION}_linux_${IMAGE_ARCH}.tar.gz /tmp/entrypoint-demoter.tar.gz
 
-RUN mkdir -p /opt/entrypoint-demoter && \
-    tar x -f /tmp/entrypoint-demoter.tar.gz -C /opt/entrypoint-demoter && \
-    rm /tmp/entrypoint-demoter.tar.gz
+RUN tar x -f /tmp/entrypoint-demoter.tar.gz -C /opt/ && \
+    chmod +x /opt/entrypoint-demoter
 
+ARG RCLONE_VERSION=1.49.5
+
+ADD https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${IMAGE_ARCH}.zip /tmp/rclone.zip
+
+RUN mkdir -p /tmp/rclone && \
+    unzip /tmp/rclone.zip -d /tmp/rclone && \
+    mv /tmp/rclone/rclone-v${RCLONE_VERSION}-linux-${IMAGE_ARCH}/rclone /opt/rclone && \
+    chmod +x /opt/rclone
 
 
 FROM alpine
@@ -33,21 +42,25 @@ RUN apk -U --no-cache add \
     bash \
     coreutils
 
-COPY --from=builder /opt/rcon-cli/rcon-cli /opt/rcon-cli/rcon-cli
+COPY --from=builder /opt/rcon-cli /opt/rcon-cli
 
-RUN ln -s /opt/rcon-cli/rcon-cli /usr/bin
+RUN ln -s /opt/rcon-cli /usr/bin
 
 COPY --from=builder /opt/restic /opt/restic
 
-RUN chmod +x /opt/restic && \
-    ln -s /opt/restic /usr/bin
+RUN ln -s /opt/restic /usr/bin
 
-COPY --from=builder /opt/entrypoint-demoter/entrypoint-demoter /opt/entrypoint-demoter
+COPY --from=builder /opt/entrypoint-demoter /opt/entrypoint-demoter
 
-RUN chmod +x /opt/entrypoint-demoter && \
-    ln -s /opt/entrypoint-demoter /usr/bin
+RUN ln -s /opt/entrypoint-demoter /usr/bin
+
+COPY --from=builder /opt/rclone /opt/rclone
+
+RUN ln -s /opt/rclone /usr/bin
 
 COPY backup-loop.sh /opt/
+
+RUN chmod +x /opt/backup-loop.sh
 
 VOLUME ["/data", "/backups"]
 

--- a/tests/test.simple.restic.sh
+++ b/tests/test.simple.restic.sh
@@ -42,6 +42,7 @@ timeout --kill-after=20 50 docker run --rm \
     --env PRUNE_BACKUPS_DAYS \
     --env RESTIC_REPOSITORY \
     --env RESTIC_PASSWORD \
+    --env DEBUG \
     --env BACKUP_METHOD=restic \
     --mount "type=bind,src=${LOCAL_SRC_DIR},dst=${SRC_DIR}" \
     --mount "type=bind,src=${LOCAL_DEST_DIR},dst=${DEST_DIR}" \

--- a/tests/test.simple.tar.sh
+++ b/tests/test.simple.tar.sh
@@ -44,6 +44,7 @@ timeout 50 docker run --rm \
           --env INITIAL_DELAY \
           --env EXCLUDES \
           --env PRUNE_BACKUPS_DAYS \
+          --env DEBUG \
           --mount "type=bind,src=${LOCAL_SRC_DIR},dst=${SRC_DIR}" \
           --mount "type=bind,src=${LOCAL_DEST_DIR},dst=${DEST_DIR}" \
           --mount "type=bind,src=${TMP_DIR}/rcon-cli,dst=${RCON_PATH}" \


### PR DESCRIPTION
This adds `rclone` to docker image, allowing `restic` to use it to connect to more storage backends.
https://restic.readthedocs.io/en/stable/030_preparing_a_new_repo.html#other-services-via-rclone

It requires to either have the `rclone` config mounted at `~/.config/rclone/rclone.conf` (which might be tricky, because of the demoter) or use environment variables to configure it. https://rclone.org/docs/#environment-variables

Thanks to some docker layer optimization, the image size is only 13MB larger than previously (first attempt yielded image over twice as large), for a total of 73.9MB.

I was considering also adding rclone as a standalone option, but since it doesn't handle multiple versions of files, I've decided against it (though it could be useful for having a synced clone of files somewhere else)

There's 1 minor thing, which I'm not sure how to tackle yet - when using `rclone` backend and all configuration is set by environment variables, each `restic` command execution returns at least line:
```
rclone: 2019/10/12 23:10:30 NOTICE: Config file "/root/.config/rclone/rclone.conf" not found - using defaults
```
I think it provides no value in this case and should be removed.