### PR TITLE
Add ssh client to allow using SFTP backend through RCLONE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,17 @@ _common_env: &_common_env
   RCON_PATH: /usr/bin/rcon-cli
   DEBUG: true
 
+_common_install: &_common_install
+  - sudo apt-get update
+  - sudo apt-get install -y
+    tree
+    coreutils
+
+
 services:
   - docker
+
+language: bash
 
 jobs:
   include:
@@ -17,11 +26,7 @@ jobs:
     - name: Lint dockerfile
       script: bash ./tests/lint.hadolint.sh
     - name: Test simple backup and exclusion scenario with tar
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y
-          tree
-          coreutils
+      before_install: *_common_install
       env:
         <<: *_common_env
         EXTRACT_DIR: /tmp/extract
@@ -29,11 +34,7 @@ jobs:
         PRUNE_BACKUPS_DAYS: 3
       script: bash ./tests/test.simple.tar.sh
     - name: Test restic handling
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y
-          tree
-          coreutils
+      before_install: *_common_install
       env:
         <<: *_common_env
         RESTIC_REPOSITORY: /tmp/dest
@@ -41,11 +42,7 @@ jobs:
         RESTIC_PASSWORD: 1234
       script: bash ./tests/test.simple.restic.sh
     - name: Test restic rclone handling
-      before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y
-          tree
-          coreutils
+      before_install: *_common_install
       env:
         <<: *_common_env
         RESTIC_REPOSITORY: rclone:/tmp/dest

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,29 +40,41 @@ FROM alpine
 
 RUN apk -U --no-cache add \
     bash \
-    coreutils
+    coreutils \
+    openssh-client
+
 
 COPY --from=builder /opt/rcon-cli /opt/rcon-cli
 
 RUN ln -s /opt/rcon-cli /usr/bin
 
+
 COPY --from=builder /opt/restic /opt/restic
 
 RUN ln -s /opt/restic /usr/bin
+
 
 COPY --from=builder /opt/entrypoint-demoter /opt/entrypoint-demoter
 
 RUN ln -s /opt/entrypoint-demoter /usr/bin
 
+
 COPY --from=builder /opt/rclone /opt/rclone
 
 RUN ln -s /opt/rclone /usr/bin
+
 
 COPY backup-loop.sh /opt/
 
 RUN chmod +x /opt/backup-loop.sh
 
+
 VOLUME ["/data", "/backups"]
+
+# Workaround for some tools (i.e. RCLONE) creating cache files in $HOME
+# and not having permissions to write when demoter does demote to UID,
+# while keeping the $HOME=/root
+ENV HOME=/tmp
 
 ENTRYPOINT ["/opt/entrypoint-demoter", "--match", "/backups"]
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ At least one of `RESTIC_PASSWORD*` variables need to be defined, along with `RES
 :warning: | When using restic, at least one of `HOSTNAME` or `BACKUP_NAME` must be unique, when sharing a repository. Otherwise other instances using the same repository might prune your backups prematurely.
 ---|---
 
-:warning: | SFTP restic backend is not directly supported. Please user RCLONE backend with SFTP support.
+:warning: | SFTP restic backend is not directly supported. Please use RCLONE backend with SFTP support.
 ---|---
 
 ## Volumes

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ At least one of `RESTIC_PASSWORD*` variables need to be defined, along with `RES
 :warning: | When using restic, at least one of `HOSTNAME` or `BACKUP_NAME` must be unique, when sharing a repository. Otherwise other instances using the same repository might prune your backups prematurely.
 ---|---
 
+:warning: | SFTP restic backend is not directly supported. Please user RCLONE backend with SFTP support.
+---|---
+
 ## Volumes
 
 - `/data` :

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -49,6 +49,7 @@ log() {
   shift
   local valid_levels=(
     "INFO"
+    "WARN"
     "ERROR"
     "INTERNALERROR"
   )


### PR DESCRIPTION
This allows to use SFTP restic backend through RCLONE. Unfortunately using SFTP as a direct restic backend is not supported - it'd require more work, most probably including changes to entrypoint-demoter. 