### PR TITLE
feat(restic): add options to finetune restic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `INITIAL_DELAY`=2m
 - `BACKUP_INTERVAL`=24h
 - `PRUNE_BACKUPS_DAYS`=7
+- `PRUNE_RESTIC_RETENTION`=--keep-within 7d
 - `RCON_HOST`=localhost
 - `RCON_PORT`=25575
 - `RCON_PASSWORD`=minecraft
@@ -44,6 +45,10 @@ Examples:
 See [restic documentation](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html) on what variables are needed to be defined.
 At least one of `RESTIC_PASSWORD*` variables need to be defined, along with `RESTIC_REPOSITORY`.
 
+You can finetune the retention cycle of the restic backups using the `PRUNE_RESTIC_RETENTION` variable. Take a look at the [restic documentation](https://restic.readthedocs.io/en/latest/060_forget.html) for details.
+
+> **_EXAMPLE_**  
+> Setting `PRUNE_RESTIC_RETENTION` to `--keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 75` will keep the most recent 7 daily snapshots, then 4 (remember, 7 dailies already include a week!) last-day-of-the-weeks and 11 or 12 last-day-of-the-months (11 or 12 depends if the 5 weeklies cross a month). And finally 75 last-day-of-the-year snapshots. All other snapshots are removed.
 
 :warning: | When using restic as your backup method, make sure that you fix your container hostname to a constant value! Otherwise, each time a container restarts it'll use a different, random hostname which will cause it not to rotate your backups created by previous instances!
 ---|---

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `RCON_PASSWORD`=minecraft
 - `EXCLUDES`=\*.jar,cache,logs
 - `BACKUP_METHOD`=tar
+- `RESTIC_ADDITIONAL_TAGS`=mc_backups
 
 If `PRUNE_BACKUPS_DAYS` is set to a positive number, it'll delete old `.tgz` backup files from `DEST_DIR`. By default deletes backups older than a week.
 
@@ -44,6 +45,8 @@ Examples:
 
 See [restic documentation](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html) on what variables are needed to be defined.
 At least one of `RESTIC_PASSWORD*` variables need to be defined, along with `RESTIC_REPOSITORY`.
+
+Use the `RESTIC_ADDITIONAL_TAGS` variable to define a space separated list of additional restic tags. The backup will always be tagged with the value of `BACKUP_NAME`. e.g.: `RESTIC_ADDITIONAL_TAGS=mc_backups foo bar` will tag your backup with `foo`, `bar`, `mc_backups` and the value of `BACKUP_NAME`.
 
 You can finetune the retention cycle of the restic backups using the `PRUNE_RESTIC_RETENTION` variable. Take a look at the [restic documentation](https://restic.readthedocs.io/en/latest/060_forget.html) for details.
 

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -13,6 +13,7 @@ fi
 : "${BACKUP_INTERVAL:=${INTERVAL_SEC:-24h}}"
 : "${BACKUP_METHOD:=tar}" # currently one of tar, restic
 : "${PRUNE_BACKUPS_DAYS:=7}"
+: "${PRUNE_RESTIC_RETENTION:=--keep-within ${PRUNE_BACKUP_DAYS:-7}d}"
 : "${RCON_HOST:=localhost}"
 : "${RCON_PORT:=25575}"
 : "${RCON_PASSWORD:=minecraft}"
@@ -179,7 +180,7 @@ tar() {
 
 restic() {
   _delete_old_backups() {
-    command restic forget --tag "${restic_tags_filter}" --keep-within "${PRUNE_BACKUPS_DAYS}d" "${@}"
+    command restic forget --tag "${restic_tags_filter}" "${PRUNE_RESTIC_RETENTION}" "${@}"
   }
   _check() {
       if ! output="$(command restic check 2>&1)"; then

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -181,7 +181,7 @@ tar() {
 
 restic() {
   _delete_old_backups() {
-    command restic forget --tag "${restic_tags_filter}" "${PRUNE_RESTIC_RETENTION}" "${@}"
+    command restic forget --tag "${restic_tags_filter}" ${PRUNE_RESTIC_RETENTION} "${@}"
   }
   _check() {
       if ! output="$(command restic check 2>&1)"; then
@@ -226,8 +226,7 @@ restic() {
     restic_tags_arguments=()
     local tag
     for tag in "${restic_tags[@]}"; do
-        local tag_arg="--tag $tag"
-        restic_tags_arguments+=("$tag_arg")
+        restic_tags_arguments+=( --tag "$tag")
     done
     readonly restic_tags_arguments
     # Used for filtering backups to only match ours

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -19,6 +19,7 @@ fi
 : "${RCON_PASSWORD:=minecraft}"
 : "${EXCLUDES:=*.jar,cache,logs}" # Comma separated list of glob(3) patterns
 : "${LINK_LATEST:=false}"
+: "${RESTIC_ADDITIONAL_TAGS:=mc_backups}" # Space separated list of restic tags
 
 export RCON_HOST
 export RCON_PORT
@@ -217,15 +218,17 @@ restic() {
     fi
 
     # Used to construct tagging arguments and filters for snapshots
-    readonly restic_tags=(
-      "mc_backups"
-      "${BACKUP_NAME}"
-    )
+    restic_tags=(${RESTIC_ADDITIONAL_TAGS})
+    restic_tags+=("${BACKUP_NAME}")
+    readonly restic_tags
+    
     # Arguments to use to tag the snapshots with
     restic_tags_arguments=()
     local tag
     for tag in "${restic_tags[@]}"; do
-      restic_tags_arguments+=( --tag "${tag}" )
+        local tag_arg="--tag $tag"
+        echo $tag_arg
+        restic_tags_arguments+=("$tag_arg")
     done
     readonly restic_tags_arguments
     # Used for filtering backups to only match ours

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -227,7 +227,6 @@ restic() {
     local tag
     for tag in "${restic_tags[@]}"; do
         local tag_arg="--tag $tag"
-        echo $tag_arg
         restic_tags_arguments+=("$tag_arg")
     done
     readonly restic_tags_arguments


### PR DESCRIPTION
- Added the variable `PRUNE_RESTIC_RETENTION` to control the restic backup retention.
- Defaults to `--keep-within ${PRUNE_BACKUP_DAYS:-7}d)`
- Added `RESTIC_ADDITIONAL_TAGS` that allows adding additional restic backup tags

Restic provides great methods for fine tuning backup retention times, which should be controllable with the container.

*I still need to test this, that's why there is a WIP label.*

P.s.: @itzg do you have Discord or another contact method so we discuss possible contributions for the `itzg/minecraft-server` image? You can add me on Discord: Silthus#4973