### PR TITLE
Initial push for ARM64 Arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM alpine AS builder
+FROM arm64v8/alpine:latest AS builder
 
 RUN mkdir -p /opt
 
-ARG IMAGE_ARCH=amd64
+ARG IMAGE_ARCH=arm64
 
-ARG RCON_CLI_VERSION=1.4.4
+ARG RCON_CLI_VERSION=1.4.8
 
 ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VERSION}/rcon-cli_${RCON_CLI_VERSION}_linux_${IMAGE_ARCH}.tar.gz /tmp/rcon-cli.tar.gz
 
 RUN tar x -f /tmp/rcon-cli.tar.gz -C /opt/ && \
     chmod +x /opt/rcon-cli
 
-ARG RESTIC_VERSION=0.9.5
+ARG RESTIC_VERSION=0.11.0
 
 ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_${IMAGE_ARCH}.bz2 /tmp/restic.bz2
 
@@ -19,14 +19,14 @@ RUN bunzip2 /tmp/restic.bz2 && \
     mv /tmp/restic /opt/restic && \
     chmod +x /opt/restic
 
-ARG DEMOTER_VERSION=0.1.0
+ARG DEMOTER_VERSION=0.3.0
 
-ADD https://github.com/itzg/entrypoint-demoter/releases/download/${DEMOTER_VERSION}/entrypoint-demoter_${DEMOTER_VERSION}_linux_${IMAGE_ARCH}.tar.gz /tmp/entrypoint-demoter.tar.gz
+ADD https://github.com/itzg/entrypoint-demoter/releases/download/v${DEMOTER_VERSION}/entrypoint-demoter_${DEMOTER_VERSION}_Linux_${IMAGE_ARCH}.tar.gz /tmp/entrypoint-demoter.tar.gz
 
 RUN tar x -f /tmp/entrypoint-demoter.tar.gz -C /opt/ && \
     chmod +x /opt/entrypoint-demoter
 
-ARG RCLONE_VERSION=1.49.5
+ARG RCLONE_VERSION=1.53.3
 
 ADD https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${IMAGE_ARCH}.zip /tmp/rclone.zip
 
@@ -36,7 +36,7 @@ RUN mkdir -p /tmp/rclone && \
     chmod +x /opt/rclone
 
 
-FROM alpine
+FROM arm64v8/alpine:latest
 
 RUN apk -U --no-cache add \
     bash \


### PR DESCRIPTION
Hey Geoff,

Just made a arm64 branch and tested on my Raspberry Pi 4. Working great! Not sure if you'd like to add this as a branch in your main repo. Thanks for all the work on this. I got to learn a lot about restic and rclone!

Changed Alpine Docker image to arm64 supported tag

Changed ARG IMAGE_ARCH to arm64

Updated software version dependencies

Changed Demoter github release url to reflect newer naming conventions