### PR TITLE
Add option to pause backups when no players are online

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,21 @@ FROM alpine AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 
+RUN mkdir -p /opt
+
 ARG RCON_CLI_VERSION=1.4.8
 
 ADD https://github.com/itzg/rcon-cli/releases/download/${RCON_CLI_VERSION}/rcon-cli_${RCON_CLI_VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/rcon-cli.tar.gz
 
-RUN mkdir -p /opt && \
-    tar x -f /tmp/rcon-cli.tar.gz -C /opt/ && \
+RUN tar x -f /tmp/rcon-cli.tar.gz -C /opt/ && \
     chmod +x /opt/rcon-cli
+
+ARG MC_MONITOR_VERSION=0.10.0
+
+ADD https://github.com/itzg/mc-monitor/releases/download/${MC_MONITOR_VERSION}/mc-monitor_${MC_MONITOR_VERSION}_linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/mc-monitor.tar.gz
+
+RUN tar x -f /tmp/mc-monitor.tar.gz -C /opt/ && \
+    chmod +x /opt/mc-monitor
 
 ARG RESTIC_VERSION=0.11.0
 
@@ -52,6 +60,11 @@ RUN apk -U --no-cache add \
 COPY --from=builder /opt/rcon-cli /opt/rcon-cli
 
 RUN ln -s /opt/rcon-cli /usr/bin
+
+
+COPY --from=builder /opt/mc-monitor /opt/mc-monitor
+
+RUN ln -s /opt/mc-monitor /usr/bin
 
 
 COPY --from=builder /opt/restic /opt/restic

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `BACKUP_NAME`=world
 - `INITIAL_DELAY`=2m
 - `BACKUP_INTERVAL`=24h
+- `PAUSE_IF_NO_PLAYERS`=false
 - `PRUNE_BACKUPS_DAYS`=7
 - `PRUNE_RESTIC_RETENTION`=--keep-within 7d
+- `SERVER_PORT`=25565
 - `RCON_HOST`=localhost
 - `RCON_PORT`=25575
 - `RCON_PASSWORD`=minecraft
@@ -35,6 +37,10 @@ Examples:
 - `BACKUP_INTERVAL`="1.5d" -> backup every one and a half days (36 hours)
 - `BACKUP_INTERVAL`="2h 30m" -> backup every two and a half hours
 - `INITIAL_DELAY`="120" -> wait 2 minutes before starting
+
+The `PAUSE_IF_NO_PLAYERS` option lets you pause backups if no players are online.
+
+If `PAUSE_IF_NO_PLAYERS`="true" and there are no players online after a backup is made, then instead of immediately scheduling the next backup, the script will start checking the server's player count every minute. Once a player joins the server, the next backup will be scheduled in `BACKUP_INTERVAL`.
 
 `EXCLUDES` is a comma-separated list of glob(3) patterns to exclude from backups. By default excludes all jar files (plugins, server files), logs folder and cache (used by i.e. PaperMC server).
 

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -11,10 +11,12 @@ fi
 : "${BACKUP_NAME:=world}"
 : "${INITIAL_DELAY:=2m}"
 : "${BACKUP_INTERVAL:=${INTERVAL_SEC:-24h}}"
+: "${PAUSE_IF_NO_PLAYERS:=false}"
 : "${BACKUP_METHOD:=tar}" # currently one of tar, restic
 : "${TAR_COMPRESS_METHOD:=gzip}"  # bzip2 gzip
 : "${PRUNE_BACKUPS_DAYS:=7}"
 : "${PRUNE_RESTIC_RETENTION:=--keep-within ${PRUNE_BACKUP_DAYS:-7}d}"
+: "${SERVER_PORT:=25565}"
 : "${RCON_HOST:=localhost}"
 : "${RCON_PORT:=25575}"
 : "${RCON_PASSWORD:=minecraft}"
@@ -349,9 +351,23 @@ while true; do
   # Only raw numeric value <= 0 will break
   if (( BACKUP_INTERVAL <= 0 )) &>/dev/null; then
     break
-  else
-    log INFO "sleeping ${BACKUP_INTERVAL}..."
-    # shellcheck disable=SC2086
-    sleep ${BACKUP_INTERVAL}
   fi
+  
+  if [[ ${PAUSE_IF_NO_PLAYERS^^} = TRUE ]]; then
+    while true; do
+      if ! PLAYERS_ONLINE=$(mc-monitor status --host "${RCON_HOST}" --port "${SERVER_PORT}" --show-player-count 2>&1); then
+        log ERROR "Error querying the server, waiting 1 minute..."
+        sleep 1m
+      elif [ ${PLAYERS_ONLINE} = 0 ]; then
+        log INFO "No players online, waiting 1 minute..."
+        sleep 1m
+      else
+        break
+      fi
+    done
+  fi
+  
+  log INFO "sleeping ${BACKUP_INTERVAL}..."
+  # shellcheck disable=SC2086
+  sleep ${BACKUP_INTERVAL}
 done


### PR DESCRIPTION
Added two new arguments:

- `PAUSE_IF_NO_PLAYERS` toggles the feature
- `SERVER_PORT` is required for querying the server's player count

From README:

> If `PAUSE_IF_NO_PLAYERS`="true" and there are no players online after a backup is made, then instead of immediately scheduling the next backup, the script will start checking the server's player count every minute. Once a player joins the server, the next backup will be scheduled in `BACKUP_INTERVAL`.