### PR TITLE
Add env var to customise "players are online" check interval

### DIFF
--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -12,6 +12,7 @@ fi
 : "${INITIAL_DELAY:=2m}"
 : "${BACKUP_INTERVAL:=${INTERVAL_SEC:-24h}}"
 : "${PAUSE_IF_NO_PLAYERS:=false}"
+: "${PLAYERS_ONLINE_CHECK_INTERVAL:=5m}"
 : "${BACKUP_METHOD:=tar}" # currently one of tar, restic
 : "${TAR_COMPRESS_METHOD:=gzip}"  # bzip2 gzip
 : "${PRUNE_BACKUPS_DAYS:=7}"
@@ -352,21 +353,21 @@ while true; do
   if (( BACKUP_INTERVAL <= 0 )) &>/dev/null; then
     break
   fi
-  
+
   if [[ ${PAUSE_IF_NO_PLAYERS^^} = TRUE ]]; then
     while true; do
       if ! PLAYERS_ONLINE=$(mc-monitor status --host "${RCON_HOST}" --port "${SERVER_PORT}" --show-player-count 2>&1); then
-        log ERROR "Error querying the server, waiting 1 minute..."
-        sleep 1m
+        log ERROR "Error querying the server, waiting ${PLAYERS_ONLINE_CHECK_INTERVAL}..."
+        sleep "${PLAYERS_ONLINE_CHECK_INTERVAL}"
       elif [ ${PLAYERS_ONLINE} = 0 ]; then
-        log INFO "No players online, waiting 1 minute..."
-        sleep 1m
+        log INFO "No players online, waiting ${PLAYERS_ONLINE_CHECK_INTERVAL}..."
+        sleep "${PLAYERS_ONLINE_CHECK_INTERVAL}"
       else
         break
       fi
     done
   fi
-  
+
   log INFO "sleeping ${BACKUP_INTERVAL}..."
   # shellcheck disable=SC2086
   sleep ${BACKUP_INTERVAL}


### PR DESCRIPTION
For my server, checking once a minute is massive overkill. Sometimes it
goes more than a week without anyone playing. The last thing I need is
my disk filling up with "waiting 1 minute" logs. I would argue once a
minute by default is overkill for anyone using this feature, so I set
the timeout at 5 minutes by default.