### PR TITLE
Add flush option to save-all call

### DIFF
--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -335,7 +335,7 @@ while true; do
     # or gets shut down, we want to make sure saving is on
     trap 'retry 5 5s rcon-cli save-on' EXIT
 
-    retry ${RCON_RETRIES} ${RCON_RETRY_INTERVAL} rcon-cli save-all
+    retry ${RCON_RETRIES} ${RCON_RETRY_INTERVAL} rcon-cli save-all flush
     retry ${RCON_RETRIES} ${RCON_RETRY_INTERVAL} sync
 
     "${BACKUP_METHOD}" backup


### PR DESCRIPTION
I use this project together with your minecraft-server image on Minecraft version 1.18.
The tar call fails for me because apparently the minecraft server is still writing to the disk when calling save-all without flush.
```
2021-12-05T18:35:18+0000 INFO Backing up content in /data to /backups/world-20211205-183518.tgz
+ '[' INFO == INTERNALERROR ']'
+ command tar --exclude '*.jar' --exclude cache --exclude logs --gzip -cf /backups/world-20211205-183518.tgz -C /data .
tar: ./world/entities/r.0.0.mca: file changed as we read it
```