### PR TITLE
Add support for reading RCON password from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `RCON_HOST`=localhost
 - `RCON_PORT`=25575
 - `RCON_PASSWORD`=minecraft
+- `RCON_PASSWORD_FILE`: Can be set to read the RCON password from a file. Overrides `RCON_PASSWORD` if both are set.
 - `RCON_RETRIES`=5 : Set to a negative value to retry indefinitely
 - `RCON_RETRY_INTERVAL`=10s
 - `EXCLUDES`=\*.jar,cache,logs

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -21,6 +21,7 @@ fi
 : "${SERVER_PORT:=25565}"
 : "${RCON_HOST:=localhost}"
 : "${RCON_PORT:=25575}"
+: "${RCON_PASSWORD_FILE:=}"
 : "${RCON_PASSWORD:=minecraft}"
 : "${RCON_RETRIES:=5}"
 : "${RCON_RETRY_INTERVAL:=10s}"
@@ -362,7 +363,18 @@ rclone() {
 ## main ##
 ##########
 
-
+if [[ $RCON_PASSWORD_FILE ]]; then
+  if [ ! -e ${RCON_PASSWORD_FILE} ]; then
+    log ERROR "Initial RCON password file ${RCON_PASSWORD_FILE} does not seems to exist."
+    log ERROR "Please ensure your configuration."
+    log ERROR "If you are using Docker Secrets feature, please check this for further information: "
+    log ERROR " https://docs.docker.com/engine/swarm/secrets"
+    exit 1
+  else
+    RCON_PASSWORD=$(cat ${RCON_PASSWORD_FILE})
+    export RCON_PASSWORD
+  fi
+fi
 
 if [ -n "${INTERVAL_SEC:-}" ]; then
   log WARN 'INTERVAL_SEC is deprecated. Use BACKUP_INTERVAL instead'


### PR DESCRIPTION
Closes #77. I tested this PR using the following stack definition

```yaml
version: '3.7'

services:
  vanilla:
    image: docker.io/itzg/minecraft-server:java8
    environment:
      - VERSION=1.12.2
      - EULA=TRUE
      - RCON_ENABLED=true
      - RCON_PASSWORD_FILE=/run/secrets/vanilla-rcon-password
    volumes:
      - vanilla-data:/data
    secrets:
      - vanilla-rcon-password
    ports:
      - 25565:25565
    tty: true
    stdin_open: true
  vanilla-backup:
    image: 127.0.0.1:5000/mc-backup-pr
    environment:
      - BACKUP_INTERVAL=5m
      - RCON_HOST=vanilla
      - RCON_PASSWORD_FILE=/run/secrets/vanilla-rcon-password
      - EXCLUDES=*.jar,cache,logs,mods,tmp,llibrary,libraries,*.so
    volumes:
      - vanilla-data:/data:ro
      - vanilla-backups:/backups
    secrets:
      - vanilla-rcon-password

volumes:
  vanilla-data:
  vanilla-backups:

secrets:
  vanilla-rcon-password:
    external: true
```

I lifted the code for this PR pretty much straight from the docker-minecraft-server repo.