### PR TITLE
Support for pre/post-backup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Provides a side-car container to backup itzg/minecraft-server world data.
 - `BACKUP_METHOD`=tar
 - `RESTIC_ADDITIONAL_TAGS`=mc_backups
 - `TZ` : Can be set to the timezone to use for logging
-- `PRE_BACKUP_COMMANDS` and `POST_BACKUP_COMMANDS`: a newline-delimited list of commands to run before and after the backup. See [Pre/post-backup commands](#prepost-backup-commands) for details
+- `PRE_BACKUP_SCRIPT`, `PRE_BACKUP_SCRIPT_FILE`, `POST_BACKUP_SCRIPT`, `POST_BACKUP_SCRIPT_FILE`: See [Pre/post-backup scripts](#prepost-backup-scripts)
 
 If `PRUNE_BACKUPS_DAYS` is set to a positive number, it'll delete old `.tgz` backup files from `DEST_DIR`. By default deletes backups older than a week.
 
@@ -137,16 +137,27 @@ This mechanism can also be used to avoid a long running container completely by 
 docker run --rm ...data and backup -v args... itzg/mc-backup backup now
 ```
 
-## Pre/post-backup commands
+## Pre/post-backup script
 
-The `PRE_BACKUP_COMMANDS` and `POST_BACKUP_COMMANDS` variables may be set to a newline-delimited list of bash commands to run before and after the backup, respectively. Potential use-cases include sending notifications, or replicating a restic repository to a remote store.
+The `PRE_BACKUP_SCRIPT` and `POST_BACKUP_SCRIPT` variables may be set to a bash script to run before and after the backup, respectively. Potential use-cases include sending notifications, or replicating a restic repository to a remote store.
+
+Alternatively `PRE_BACKUP_SCRIPT_FILE` and `POST_BACKUP_SCRIPT_FILE` may be set to the path of a script that has been mounted into the container. The file must be executable.
+
+Note that `*_FILE` variables will be overridden by their non-FILE versions if both are set.
 
 Some notes:
 
-- When specifying the commands in Docker compose files any `$` that are being used to refer to environment variables must be doubled up (i.e. `$$`) else Compose will try to substitute them
-- Multi-line commands will not work
+- When specifying the script directly in Docker compose files any `$` that are being used to refer to environment variables must be doubled up (i.e. `$$`) else Compose will try to substitute them
 
 ### Example
+
+With a executable file called `post-backup.sh` next to the compose file with the following contents
+
+```sh
+echo "Backup from $RCON_HOST to $DEST_DIR finished"
+```
+
+and the following compose definition
 
 ```yaml
 version: '3.7'
@@ -166,17 +177,17 @@ services:
     environment:
       BACKUP_INTERVAL: "2h"
       RCON_HOST: mc
-      PRE_BACKUP_COMMANDS: |
+      PRE_BACKUP_SCRIPT: |
         echo "Before backup!"
         echo "Also before backup from $$RCON_HOST to $$DEST_DIR"
-      POST_BACKUP_COMMANDS: |
-        echo "Backup from $$RCON_HOST to $$DEST_DIR finished"
+      POST_BACKUP_SCRIPT_FILE: /post-backup.sh
     volumes:
       # mount the same volume used by server, but read-only
       - mc:/data:ro
       # use a host attached directory so that it in turn can be backed up
       # to external/cloud storage
       - ./mc-backups:/backups
+      - ./post-backup.sh:/post-backup.sh:ro
 
 volumes:
   mc: {}

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -171,15 +171,6 @@ call_if_function_exists() {
   fi
 }
 
-run_commands() {
-  local _commands
-  readarray -t _commands <<<"$1"
-
-  for line in "${_commands[@]}"; do
-    eval "$line"
-  done
-}
-
 #####################
 ## specific method ##
 ##    functions    ##


### PR DESCRIPTION
Implements both methods discussed in #68 through four new environment variables

- `PRE_BACKUP_SCRIPT`
- `PRE_BACKUP_SCRIPT_FILE`
- `POST_BACKUP_SCRIPT`
- `POST_BACKUP_SCRIPT_FILE`

The non-`*_FILE` variables take precedence if both are specified.

Some things I want to address before merging:

- The pre-backup script runs after auto save has been disabled, and the post-backup script runs after it's been reenabled. Does this seem like the best way to do it?
- Ideally the post-backup script would still be able to run if the backup failed, to push a failure notification for example. But given the `set -e` at the script's start the container will exit if the backup fails.
- On that note, a way for the post-backup script to know how the backup went. Given that they're real scripts an argument would work, but so would an exported environment variable
- And on *that* note, in order to not force `set -euo pipefail` on the scripts I'm not sourcing them, but that also means they can only see exported environment variables. I've added some exports for variables that I think would be useful, but it doesn't feel elegant to do it like that