### PR TITLE
Separate dat files compression to avoid "file changed as we read it" error in huge worlds

### DIFF
--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -177,7 +177,7 @@ call_if_function_exists() {
 
 tar() {
   _find_old_backups() {
-    find "${DEST_DIR}" -maxdepth 1 -name "*.${backup_extension}" -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
+    find "${DEST_DIR}" -maxdepth 1 -name "*.tar.${backup_extension}" -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
   }
 
   init() {

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -177,7 +177,7 @@ call_if_function_exists() {
 
 tar() {
   _find_old_backups() {
-    find "${DEST_DIR}" -maxdepth 1 -name "*.tar.${backup_extension}" -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
+    find "${DEST_DIR}" -maxdepth 1 -name "*.tgz" -o -name "*.${backup_extension}" -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
   }
 
   init() {

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -219,7 +219,7 @@ tar() {
       (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
 
       if [ ${exitCode:-0} -eq 1 ]; then
-        log ERROR "dat files changed during backup"
+        log WARN "dat files changed during backup"
         return
       elif [ ${exitCode:-0} -gt 1 ]; then
         log ERROR "tar exited with code ${exitCode}! Aborting"
@@ -382,7 +382,7 @@ rclone() {
       (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
 
       if [ ${exitCode:-0} -eq 1 ]; then
-        log ERROR "dat files changed during backup"
+        log WARN "dat files changed during backup"
         return
       elif [ ${exitCode:-0} -gt 1 ]; then
         log ERROR "tar exited with code ${exitCode}! Aborting"
@@ -414,8 +414,8 @@ rclone() {
       log WARN "Cannot compress backup"
     fi
 
-    command rclone copy "${outFile}.tar.${backup_extension}" "${RCLONE_REMOTE}:${RCLONE_DEST_DIR}"
-    rm "${outFile}"
+    command rclone copy "${outFile}.${backup_extension}" "${RCLONE_REMOTE}:${RCLONE_DEST_DIR}"
+    rm "${outFile}.${backup_extension}"
   }
   prune() {
     if [ -n "$(_find_old_backups)" ]; then

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -241,6 +241,9 @@ tar() {
     fi
     exitCode=0
 
+    # enable saving while we compress backup
+    retry 5 5s rcon-cli save-on
+
     # compress backup
     log INFO "Compressing backup ${outFile}"
     command "${compress_command[@]}" "${outFile}" || exitCode=$?
@@ -400,6 +403,9 @@ rclone() {
       exit 1
     fi
     exitCode=0
+
+    # enable saving while we compress backup
+    retry 5 5s rcon-cli save-on
 
     # compress backup
     log INFO "Compressing backup ${outFile}"

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -212,7 +212,19 @@ tar() {
     # backup dat and dat_old files separately
     (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
     if [ ${exitCode:-0} -eq 1 ]; then
-      log ERROR "dat files changed during backup"
+      log ERROR "dat files changed during backup. Retrying in 5 seconds"
+      sleep 5
+      exitCode=0
+
+      (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
+
+      if [ ${exitCode:-0} -eq 1 ]; then
+        log ERROR "dat files changed during backup"
+        return
+      elif [ ${exitCode:-0} -gt 1 ]; then
+        log ERROR "tar exited with code ${exitCode}! Aborting"
+        exit 1
+      fi
       return
     elif [ ${exitCode:-0} -gt 1 ]; then
       log ERROR "tar exited with code ${exitCode}! Aborting"
@@ -360,7 +372,19 @@ rclone() {
     # backup dat and dat_old files separately
     (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
     if [ ${exitCode:-0} -eq 1 ]; then
-      log ERROR "dat files changed during backup"
+      log ERROR "dat files changed during backup. Retrying in 5 seconds"
+      sleep 5
+      exitCode=0
+
+      (cd "${SRC_DIR}" && find . -type f -name "*.dat" -o -name "*.dat_old" ) | command tar "${excludes[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
+
+      if [ ${exitCode:-0} -eq 1 ]; then
+        log ERROR "dat files changed during backup"
+        return
+      elif [ ${exitCode:-0} -gt 1 ]; then
+        log ERROR "tar exited with code ${exitCode}! Aborting"
+        exit 1
+      fi
       return
     elif [ ${exitCode:-0} -gt 1 ]; then
       log ERROR "tar exited with code ${exitCode}! Aborting"

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -414,7 +414,7 @@ rclone() {
       log WARN "Cannot compress backup"
     fi
 
-    command rclone copy "${outFile}.${backup_extension}" "${RCLONE_REMOTE}:${RCLONE_DEST_DIR}"
+    command rclone copy "${outFile}.tar.${backup_extension}" "${RCLONE_REMOTE}:${RCLONE_DEST_DIR}"
     rm "${outFile}"
   }
   prune() {

--- a/tests/test.simple.tar.sh
+++ b/tests/test.simple.tar.sh
@@ -34,7 +34,7 @@ export RCON_PATH
 export PRUNE_BACKUPS_DAYS
 
 mkdir "${EXTRACT_DIR}"
-touch -d "$(( PRUNE_BACKUPS_DAYS + 2 )) days ago" "${LOCAL_DEST_DIR}/fake_backup_that_should_be_deleted.tgz"
+touch -d "$(( PRUNE_BACKUPS_DAYS + 2 )) days ago" "${LOCAL_DEST_DIR}/fake_backup_that_should_be_deleted.tar.gz"
 ls -al "${LOCAL_DEST_DIR}"
 
 timeout 50 docker run --rm \
@@ -51,7 +51,7 @@ timeout 50 docker run --rm \
           localhost:5000/itzg/mc-backup:latest
 
 tree "${LOCAL_DEST_DIR}"
-tar -xzf "${LOCAL_DEST_DIR}/"*.tgz -C "${EXTRACT_DIR}"
+tar -xzf "${LOCAL_DEST_DIR}/"*.tar.gz -C "${EXTRACT_DIR}"
 tree "${EXTRACT_DIR}"
 [ -z "$(find "${EXTRACT_DIR}" -name "exclude_*" -print -quit)" ]
 [ 4 -eq "$(find "${EXTRACT_DIR}" -name "backup_me*" -print | wc -l)" ]


### PR DESCRIPTION
Fixes #56.

Tested with `BACKUP_METHOD=tar`. Rclone method should probably work.

Note that backups now have extension `${name}.tar.${backup_extension}`.