### PR TITLE
Ignore tar warning

### DIFF
--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -207,25 +207,16 @@ tar() {
   backup() {
     ts=$(date +"%Y%m%d-%H%M%S")
     outFile="${DEST_DIR}/${BACKUP_NAME}-${ts}.${backup_extension}"
-    tries=3
-    while (( tries-- > 0 )); do
-      log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
-      command tar "${excludes[@]}" "${tar_parameters[@]}" -cf "${outFile}" -C "${SRC_DIR}" . || exitCode=$?
-      if [ ${exitCode:-0} -eq 0 ]; then
-        break
-      elif [ ${exitCode:-0} -eq 1 ]; then
-        if (( tries > 0 )); then
-          log INFO "...retrying backup in 5 seconds"
-          sleep 5
-          continue
-        else
-          log WARN "Giving up on this round of backup"
-        fi
-      elif [ ${exitCode:-0} -gt 1 ]; then
-        log ERROR "tar exited with code ${exitCode}! Aborting"
-        exit 1
-      fi
-    done
+    log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
+    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" . || exitCode=$?
+    if [ ${exitCode:-0} -eq 0 ]; then
+      true
+    elif [ ${exitCode:-0} -eq 1 ]; then
+      log WARN "Dat files changed as we read it"
+    elif [ ${exitCode:-0} -gt 1 ]; then
+      log ERROR "tar exited with code ${exitCode}! Aborting"
+      exit 1
+    fi
     if [ "${LINK_LATEST^^}" == "TRUE" ]; then
       ln -sf "${BACKUP_NAME}-${ts}.${backup_extension}" "${DEST_DIR}/latest.${backup_extension}"
     fi

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -208,7 +208,9 @@ tar() {
     ts=$(date +"%Y%m%d-%H%M%S")
     outFile="${DEST_DIR}/${BACKUP_NAME}-${ts}.${backup_extension}"
     log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
-    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" . || exitCode=$?
+    # sort files so that dat files are archived first
+    (cd "${SRC_DIR}" && { find . -type f -name "*.dat" -o -name "*.dat_old"; find . -type f -not -name "*.dat" -not -name "*.dat_old"; } ) |
+    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
     if [ ${exitCode:-0} -eq 0 ]; then
       true
     elif [ ${exitCode:-0} -eq 1 ]; then

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -210,7 +210,7 @@ tar() {
     log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
     # sort files so that dat files are archived first
     (cd "${SRC_DIR}" && { find . -type f -name "*.dat" -o -name "*.dat_old"; find . -type f -not -name "*.dat" -not -name "*.dat_old"; } ) |
-    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
+    command tar "${excludes[@]}" "${tar_parameters[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
     if [ ${exitCode:-0} -eq 0 ]; then
       true
     elif [ ${exitCode:-0} -eq 1 ]; then
@@ -341,7 +341,7 @@ rclone() {
     log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
     # sort files so that dat files are archived first
     (cd "${SRC_DIR}" && { find . -type f -name "*.dat" -o -name "*.dat_old"; find . -type f -not -name "*.dat" -not -name "*.dat_old"; } ) |
-    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
+    command tar "${excludes[@]}" "${tar_parameters[@]}" -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
     if [ ${exitCode:-0} -eq 0 ]; then
       true
     elif [ ${exitCode:-0} -eq 1 ]; then

--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -339,11 +339,14 @@ rclone() {
     ts=$(date +"%Y%m%d-%H%M%S")
     outFile="${DEST_DIR}/${BACKUP_NAME}-${ts}.${backup_extension}"
     log INFO "Backing up content in ${SRC_DIR} to ${outFile}"
-    command tar "${excludes[@]}" "${tar_parameters[@]}" -cf "${outFile}" -C "${SRC_DIR}" . || exitCode=$?
-    if [ ${exitCode:-0} -eq 1 ]; then
-      log WARN "tar exited with code 1. Ignoring"
-    fi
-    if [ ${exitCode:-0} -gt 1 ]; then
+    # sort files so that dat files are archived first
+    (cd "${SRC_DIR}" && { find . -type f -name "*.dat" -o -name "*.dat_old"; find . -type f -not -name "*.dat" -not -name "*.dat_old"; } ) |
+    command tar "${excludes[@]}" "${tar_parameters[@]}" --sort name -cf "${outFile}" -C "${SRC_DIR}" -T - || exitCode=$?
+    if [ ${exitCode:-0} -eq 0 ]; then
+      true
+    elif [ ${exitCode:-0} -eq 1 ]; then
+      log WARN "Dat files changed as we read it"
+    elif [ ${exitCode:-0} -gt 1 ]; then
       log ERROR "tar exited with code ${exitCode}! Aborting"
       exit 1
     fi


### PR DESCRIPTION
Fixes #56 
Closes #102 

Ignore tar warnings and archive dat files first to avoid world inconsistencies 
