### PR TITLE
Check for .paused file before querying for players

### DIFF
--- a/backup-loop.sh
+++ b/backup-loop.sh
@@ -479,7 +479,10 @@ while true; do
 
   if [[ ${PAUSE_IF_NO_PLAYERS^^} = TRUE ]]; then
     while true; do
-      if ! PLAYERS_ONLINE=$(mc-monitor status --host "${RCON_HOST}" --port "${SERVER_PORT}" --show-player-count 2>&1); then
+      if [ -e "${SRC_DIR}/.paused" ]; then
+        log INFO "Server paused, waiting ${PLAYERS_ONLINE_CHECK_INTERVAL}..."
+        sleep "${PLAYERS_ONLINE_CHECK_INTERVAL}"
+      elif ! PLAYERS_ONLINE=$(mc-monitor status --host "${RCON_HOST}" --port "${SERVER_PORT}" --show-player-count 2>&1); then
         log ERROR "Error querying the server, waiting ${PLAYERS_ONLINE_CHECK_INTERVAL}..."
         sleep "${PLAYERS_ONLINE_CHECK_INTERVAL}"
       elif [ "${PLAYERS_ONLINE}" = 0 ]; then


### PR DESCRIPTION
Closes issue #43 by checking for a file called `.paused` in the source directory before waking the server to check for players. Relies on [this PR](https://github.com/itzg/docker-minecraft-server/pull/1830) to create the file. As written, the backup loop will still wake the server to complete the backup, assuming rcon connects to the knockd interface.