### PR TITLE
added curl install from package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ FROM alpine
 RUN apk -U --no-cache add \
     bash \
     coreutils \
+    curl \
     openssh-client \
     tar \
     tzdata \


### PR DESCRIPTION
Added curl. I didn't test it but it checks out according to this site:
[https://www.cyberciti.biz/faq/how-to-install-curl-on-alpine-linux/](url)

This will address issue #140.