### PR TITLE
Update Rclone to v1.62.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ADD https://github.com/itzg/entrypoint-demoter/releases/download/v${DEMOTER_VERS
 RUN tar x -f /tmp/entrypoint-demoter.tar.gz -C /opt/ && \
     chmod +x /opt/entrypoint-demoter
 
-ARG RCLONE_VERSION=1.59.2
+ARG RCLONE_VERSION=1.62.2
 
 ADD https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${TARGETARCH}.zip /tmp/rclone.zip
 


### PR DESCRIPTION
Rclone was updated earlier this year to include a [SMB backend](https://rclone.org/smb/) in v1.60.

The version of Rclone in this image is a little bit old, so let's update it so we can use the newer SMB backend.