### PR TITLE
file_env: replace common AWS env with secrets

### DIFF
--- a/scripts/bin/backup
+++ b/scripts/bin/backup
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+# from https://medium.com/@adrian.gheorghe.dev/using-docker-secrets-in-your-environment-variables-7a0609659aab#fb39
+# small change on collision we do not exit and let the file override the env var
+file_env() {
+   local var="$1"
+   local fileVar="${var}_FILE"
+   local def="${2:-}"
+
+   if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+      echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+   fi
+   local val="$def"
+   if [ "${!var:-}" ]; then
+      val="${!var}"
+   elif [ "${!fileVar:-}" ]; then
+      val="$(< "${!fileVar}")"
+   fi
+   export "$var"="$val"
+   unset "$fileVar"
+}
+
+# common env vars which we may want to set using the <env>_FILE used by [docker secrets](https://docs.docker.com/compose/use-secrets/)
+file_env "AWS_ACCESS_KEY_ID"
+file_env "AWS_SECRET_ACCESS_KEY"
+
 args=(/opt/entrypoint-demoter --match /backups)
 
 case "$1" in


### PR DESCRIPTION
This change adds support to follow the [ENV_FILE pattern](https://docs.docker.com/compose/use-secrets/) for popular credentials like:
* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY

There are likely many others which could be added. 

An example _docker_compose.yml_ would look something like this: 

```yml
services:
  backups:
    image: itzg/mc-backup
    environment:
      BACKUP_INTERVAL: "1h"
      RCON_HOST: mc
      BACKUP_NAME: mc
      BACKUP_METHOD: restic
      RESTIC_PASSWORD_FILE: /run/secrets/restic_password 
      AWS_ACCESS_KEY_ID_FILE: /run/secrets/aws_access_key_id  
      AWS_SECRET_ACCESS_KEY_FILE: /run/secrets/aws_secret_access_key 
    secrets:
      - aws_access_key
      - aws_secret_access_key
      - restic_password
 secrets:
  aws_access_key:
    file: ../secrets/aws_access_key.txt
  aws_secret_access_key:
    file: ../secrets/aws_secret_access_key.txt
  restic_password:
    file: ../secrets/restic_password.txt
```