### PR TITLE
Add INCLUDES to narrow directories in backup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD https://github.com/itzg/mc-monitor/releases/download/${MC_MONITOR_VERSION}/m
 RUN tar x -f /tmp/mc-monitor.tar.gz -C /opt/ && \
     chmod +x /opt/mc-monitor
 
-ARG RESTIC_VERSION=0.15.2
+ARG RESTIC_VERSION=0.16.2
 
 # NOTE: restic releases don't differentiate arm v6 from v7, so TARGETVARIANT is not used
 # and have to assume they release armv7
@@ -31,7 +31,7 @@ RUN bunzip2 /tmp/restic.bz2 && \
     mv /tmp/restic /opt/restic && \
     chmod +x /opt/restic
 
-ARG DEMOTER_VERSION=0.4.0
+ARG DEMOTER_VERSION=0.4.2
 
 ADD https://github.com/itzg/entrypoint-demoter/releases/download/v${DEMOTER_VERSION}/entrypoint-demoter_${DEMOTER_VERSION}_Linux_${TARGETARCH}${TARGETVARIANT}.tar.gz /tmp/entrypoint-demoter.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `RCON_PASSWORD_FILE`: Can be set to read the RCON password from a file. Overrides `RCON_PASSWORD` if both are set.
 - `RCON_RETRIES`=5 : Set to a negative value to retry indefinitely
 - `RCON_RETRY_INTERVAL`=10s
+- `INCLUDES`=. : comma separated list of directories to include relative to `/data` where `.` specifies all of `/data` should be included in the backup. 
+
+  **For Restic** the default is instead `/data` to remain backward compatible with previous images.
 - `EXCLUDES`=\*.jar,cache,logs,\*.tmp
 - `EXCLUDES_FILE`: Can be set to read the list of excludes (one per line) from a file. Can be used with `EXCLUDES` to add more excludes.
 - `BACKUP_METHOD`=tar

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `RCON_RETRY_INTERVAL`=10s
 - `INCLUDES`=. : comma separated list of directories to include relative to `/data` where `.` specifies all of `/data` should be included in the backup. 
 
-  **For Restic** the default is instead `/data` to remain backward compatible with previous images.
+  **For Restic** the default is the value of `SRC_DIR` to remain backward compatible with previous images.
 - `EXCLUDES`=\*.jar,cache,logs,\*.tmp
 - `EXCLUDES_FILE`: Can be set to read the list of excludes (one per line) from a file. Can be used with `EXCLUDES` to add more excludes.
 - `BACKUP_METHOD`=tar

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `RCON_PASSWORD_FILE`: Can be set to read the RCON password from a file. Overrides `RCON_PASSWORD` if both are set.
 - `RCON_RETRIES`=5 : Set to a negative value to retry indefinitely
 - `RCON_RETRY_INTERVAL`=10s
-- `INCLUDES`=. : comma separated list of directories to include relative to `/data` where `.` specifies all of `/data` should be included in the backup. 
+- `INCLUDES`=. : comma separated list of include patterns relative to directory specified by `SRC_DIR` where `.` specifies all of that directory should be included in the backup. 
 
   **For Restic** the default is the value of `SRC_DIR` to remain backward compatible with previous images.
 - `EXCLUDES`=\*.jar,cache,logs,\*.tmp

--- a/examples/docker-compose.restic.yml
+++ b/examples/docker-compose.restic.yml
@@ -10,14 +10,18 @@ services:
     volumes:
       - mc:/data
   backup:
-    image: itzg/mc-backup
+    image: itzg/mc-backup:local
+    depends_on:
+      mc:
+        condition: service_healthy
     environment:
       RCON_HOST: mc
       BACKUP_METHOD: restic
-      INITIAL_DELAY: 1m
+      INITIAL_DELAY: 0
       RESTIC_PASSWORD: password
       RESTIC_REPOSITORY: /backups
       PRUNE_RESTIC_RETENTION: "--keep-daily 7 --keep-weekly 5"
+      RESTIC_VERBOSE: true
     volumes:
       - mc:/data:ro
       - backups:/backup

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       RCON_HOST: mc
       # since this service waits for mc to be healthy, no initial delay is needed
       INITIAL_DELAY: 0
+      # As an example, to backup only the world data:
+      # INCLUDES: world,world_nether,world_the_end
     volumes:
       - ./mc-data:/data:ro
       - ./mc-backups:/backups

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -337,13 +337,12 @@ restic() {
     log INFO "Backing up content in ${SRC_DIR} as host ${RESTIC_HOSTNAME}"
     args=(
       --host "${RESTIC_HOSTNAME}"
-      "${restic_tags_arguments[@]}" "${excludes[@]}"
     )
     if isDebug || isTrue "$RESTIC_VERBOSE"; then
       args+=(-vv)
     fi
     (cd "$SRC_DIR" &&
-          command restic backup "${args[@]}" "${includes_patterns[@]}" | log INFO
+          command restic backup "${args[@]}" "${restic_tags_arguments[@]}" "${excludes[@]}" "${includes_patterns[@]}" | log INFO
     )
   }
   prune() {

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -277,7 +277,7 @@ tar() {
 
 
 restic() {
-  readarray -td, includes_patterns < <(printf '%s' "${INCLUDES:-/data}")
+  readarray -td, includes_patterns < <(printf '%s' "${INCLUDES:-${SRC_DIR}}")
 
   _delete_old_backups() {
     # shellcheck disable=SC2086


### PR DESCRIPTION
[Discussed in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1179094179238903849)

This also reverts some of the changes in #103 since the `find` command to lookup content
- was inefficient for large backups
- wasn't giving the expected output in the negative case, as coded
- overly complicated implementing the `INCLUDES` support and was going to limit only directories to be listed