### PR TITLE
rsync: switch from delete to exec rm #168

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -314,7 +314,7 @@ rsync() {
   prune() {
     if [ -n "$(_find_old_backups -print -quit)" ]; then
       log INFO "Pruning backup files older than ${PRUNE_BACKUPS_DAYS} days"
-      _find_old_backups -print -delete | awk '{ printf "Removing %s\n", $0 }' | log INFO
+      _find_old_backups -print -exec rm -r {} + | awk '{ printf "Removing %s\n", $0 }' | log INFO
     fi
   }
   call_if_function_exists "${@}"


### PR DESCRIPTION
This fixes #168 as it switches from `-delete` which acts like `rmdir` to `-exec rm -r +` which is like: `rm -r folder1 folder2`

There is also `-exec rm -r \;` that would be like `rm -r folder1;rm -r folder2` but I'd hope we don't get past maximum argument length cleaning the folders we just created. I'm documenting this here as it is an easy 2 character change if the other option is preferred. 

Thank you for keeping this together!