### PR TITLE
rsync: Fix link not created if exists

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -308,7 +308,7 @@ rsync() {
       exit 1
     fi
     if [ "${LINK_LATEST^^}" == "TRUE" ]; then
-      ln -s "${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
+      ln -sf "${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
     fi
   }
   prune() {


### PR DESCRIPTION
I was silly and thought `ln -sf` the `f` was file and it wasn't needed. Well it is force and that is needed to get the folder overwrote if it exists which is usually does. This adds the `f` for force back so the latest link is actually working. 