### PR TITLE
Update docker-compose.restic.yml

### DIFF
--- a/examples/docker-compose.restic.yml
+++ b/examples/docker-compose.restic.yml
@@ -23,7 +23,7 @@ services:
       PRUNE_RESTIC_RETENTION: "--keep-daily 7 --keep-weekly 5"
     volumes:
       - mc:/data:ro
-      - backups:/backup
+      - backups:/backups
 
 volumes:
   mc: {}


### PR DESCRIPTION
The RESTIC_REPOSITORY environment variable was set to the /backups directory, but the backups volume was mounted to the /backup directory in the container, which means that the restic repository would not be stored in the backups docker volume.

I've fixed the typo in the directory mount so it would work as intended. A very tiny edit.