### PR TITLE
Fixes rsync prune issue

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -300,6 +300,7 @@ rsync() {
     mkdir -p $outFile
     command rsync -a "${link_dest[@]}" "${excludes[@]}" "${SRC_DIR}/" "${outFile}/"  || exitCode=$?
     if [ ${exitCode:-0} -eq 0 ]; then
+      touch "${outFile}"
       true
     elif [ ${exitCode:-0} -eq 1 ]; then
       log WARN "Dat files changed as we read it"


### PR DESCRIPTION
Resolves #174 

`rsync -a` preserves the timestamp of the `world` folder which causes issues with the prune logic.  Adding a simple `touch` to the newly created back up folder after the sync is done, but before the prune fixes the issue.