### PR TITLE
rsync: Fix latest symlink creation

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -309,7 +309,7 @@ rsync() {
       exit 1
     fi
     if [ "${LINK_LATEST^^}" == "TRUE" ]; then
-      ln -sf "${DEST_DIR}/${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
+      ln -sfT "${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
     fi
   }
   prune() {

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -309,7 +309,7 @@ rsync() {
       exit 1
     fi
     if [ "${LINK_LATEST^^}" == "TRUE" ]; then
-      ln -sf "${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
+      ln -sf "${DEST_DIR}/${BACKUP_NAME}-${ts}" "${DEST_DIR}/latest"
     fi
   }
   prune() {


### PR DESCRIPTION
So it appears that it was treating `latest` as a directory not a target. This was... making a mess of the oldest backup by linking newer ones into that folder. The `-T` option forces the system to treat it as a target not a directory. 