### PR TITLE
Fix PRE_SAVE_ALL_SCRIPT environment variable not creating a file

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -471,6 +471,12 @@ rclone() {
 ## main ##
 ##########
 
+if [[ $PRE_SAVE_ALL_SCRIPT ]]; then
+  PRE_SAVE_ALL_SCRIPT_FILE=/tmp/pre-save-all
+  printf '#!/bin/bash\n\n%s' "$PRE_SAVE_ALL_SCRIPT" > "$PRE_SAVE_ALL_SCRIPT_FILE"
+  chmod 700 "$PRE_SAVE_ALL_SCRIPT_FILE"
+fi
+
 if [[ $PRE_BACKUP_SCRIPT ]]; then
   PRE_BACKUP_SCRIPT_FILE=/tmp/pre-backup
   printf '#!/bin/bash\n\n%s' "$PRE_BACKUP_SCRIPT" > "$PRE_BACKUP_SCRIPT_FILE"


### PR DESCRIPTION
Noticed `PRE_SAVE_ALL_SCRIPT` wasn't working and when I investigated I found it was forgotten in the file creation part of the script.