### PR TITLE
Fix a typo in the restic rclone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ services:
       # and change the above to
       # - rclone-config:/config/rclone
       - mc:/data:ro
-      - backups:/backup
+      - backups:/backups
 
 volumes:
 # Uncomment this if using the config step above

--- a/examples/docker-compose.restic-rclone.yml
+++ b/examples/docker-compose.restic-rclone.yml
@@ -24,7 +24,7 @@ services:
       # and change the above to
       # - rclone-config:/config/rclone
       - mc:/data:ro
-      - backups:/backup
+      - backups:/backups
 
 volumes:
   # Uncomment this if using the config step above


### PR DESCRIPTION
The backup volume destination was wrong