### PR TITLE
Add BACKUP_ON_STARTUP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `BACKUP_METHOD`=tar  : [see below](#backup-methods)
 - `INITIAL_DELAY`=2m
 - `BACKUP_INTERVAL`=24h
+- `BACKUP_ON_STARTUP`=true : Set to false to skip first backup on startup.
 - `PAUSE_IF_NO_PLAYERS`=false
 - `PLAYERS_ONLINE_CHECK_INTERVAL`=5m
 - `PRUNE_BACKUPS_DAYS`=7

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -579,7 +579,10 @@ fi
 first_run=TRUE
 
 while true; do
-  if ! is_paused; then
+  if [[ $first_run == TRUE && ${BACKUP_ON_STARTUP^^} = FALSE ]]; then
+    log INFO "Skipping backup on startup"
+    first_run=false
+  elif ! is_paused; then
 
     load_rcon_password
 
@@ -621,9 +624,6 @@ while true; do
       log ERROR "Unable to turn saving off. Is the server running?"
       exit 1
     fi
-  elif [[ $first_run == TRUE && ${BACKUP_ON_STARTUP^^} = FALSE ]]; then
-    log INFO "Skipping backup on startup"
-    first_run=false
   else # paused
     log INFO "Server is paused, proceeding with backup"
 

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -19,6 +19,7 @@ fi
 : "${BACKUP_NAME:=world}"
 : "${INITIAL_DELAY:=2m}"
 : "${BACKUP_INTERVAL:=${INTERVAL_SEC:-24h}}"
+: "${BACKUP_ON_STARTUP:=true}"
 : "${PAUSE_IF_NO_PLAYERS:=false}"
 : "${PLAYERS_ONLINE_CHECK_INTERVAL:=5m}"
 : "${BACKUP_METHOD:=tar}" # currently one of tar, restic, rsync
@@ -575,6 +576,7 @@ if ! is_one_shot; then
   sleep ${INITIAL_DELAY}
 fi
 
+first_run=TRUE
 
 while true; do
   if ! is_paused; then
@@ -619,6 +621,9 @@ while true; do
       log ERROR "Unable to turn saving off. Is the server running?"
       exit 1
     fi
+  elif [[ $first_run == TRUE && ${BACKUP_ON_STARTUP^^} = FALSE ]]; then
+    log INFO "Skipping backup on startup"
+    first_run=false
   else # paused
     log INFO "Server is paused, proceeding with backup"
 


### PR DESCRIPTION
Add `BACKUP_ON_STARTUP` option to configure whether a backup is initiated immediately upon start.

It can be useful to set this to `false` especially when working on your first configuration. As you iterate on your configuration and restart the backup server often, this will prevent duplicate backups for each restart.

Setting to `false` will wait for the `BACKUP_INTERVAL` before the first backup. Additionally, it will wait until a player has been active before initiating a backup according to `PAUSE_IF_NO_PLAYERS`.