### PR TITLE
Pass backup status and command output to scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SRC_DIR: /tmp/source
       DEST_DIR: /tmp/dest

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Potential use-cases include sending notifications, or replicating a restic repos
 
 The backup waits for the server to respond to a rcon "save-on" command before running the scripts. After, the `PRE_SAVE_ALL_SCRIPT` is run, followed by rcon "save-off" and "save-all" commands. The, the `PRE_BACKUP_SCRIPT` is run, followed by the backup process. Then, the `PRE_SAVE_ON_SCRIPT` is run, followed by a rcon "save-on" command. Finally, the `POST_BACKUP_SCRIPT` is run.
 
+`PRE_SAVE_ON_SCRIPT` and `POST_BACKUP_SCRIPT` are both passed the exit code of the backup as an argument. This may be used to take different actions depending on whether or not the backup failed.
+
 Alternatively `PRE_SAVE_ALL_SCRIPT_FILE` `PRE_BACKUP_SCRIPT_FILE`, `PRE_SAVE_ON_SCRIPT_FILE`, and `POST_BACKUP_SCRIPT_FILE` may be set to the path of a script that has been mounted into the container. The file must be executable.
 
 Note that `*_FILE` variables will be overridden by their non-FILE versions if both are set.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Potential use-cases include sending notifications, or replicating a restic repos
 
 The backup waits for the server to respond to a rcon "save-on" command before running the scripts. After, the `PRE_SAVE_ALL_SCRIPT` is run, followed by rcon "save-off" and "save-all" commands. The, the `PRE_BACKUP_SCRIPT` is run, followed by the backup process. Then, the `PRE_SAVE_ON_SCRIPT` is run, followed by a rcon "save-on" command. Finally, the `POST_BACKUP_SCRIPT` is run.
 
-`PRE_SAVE_ON_SCRIPT` and `POST_BACKUP_SCRIPT` are both passed the exit code of the backup as an argument. This may be used to take different actions depending on whether or not the backup failed.
+`PRE_SAVE_ON_SCRIPT` and `POST_BACKUP_SCRIPT` are both passed the exit code of the backup as the first argument, and the path to a log of the backup tool's output as the second argument. This may be used to take different actions depending on whether or not the backup failed.
 
 Alternatively `PRE_SAVE_ALL_SCRIPT_FILE` `PRE_BACKUP_SCRIPT_FILE`, `PRE_SAVE_ON_SCRIPT_FILE`, and `POST_BACKUP_SCRIPT_FILE` may be set to the path of a script that has been mounted into the container. The file must be executable.
 

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -316,6 +316,7 @@ tar() {
   call_if_function_exists "${@}"
 }
 
+# shellcheck disable=SC2317
 rsync() {
   _find_old_backups() {
     find "${DEST_DIR}" -maxdepth 1 -type d -mtime "+${PRUNE_BACKUPS_DAYS}" "${@}"
@@ -387,6 +388,7 @@ rsync() {
 }
 
 
+# shellcheck disable=SC2317
 restic() {
   readarray -td, includes_patterns < <(printf '%s' "${INCLUDES:-${SRC_DIR}}")
 
@@ -496,6 +498,7 @@ restic() {
 }
 
 
+# shellcheck disable=SC2317
 rclone() {
   readarray -td, includes_patterns < <(printf '%s' "${INCLUDES:-.}")
 

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -647,10 +647,15 @@ while true; do
         "$PRE_BACKUP_SCRIPT_FILE"
       fi
 
-      "${BACKUP_METHOD}" backup
+      backup_status=0
+      "${BACKUP_METHOD}" backup || backup_status=$?
+
+      if [[ $backup_status -ne 0 ]]; then
+        log WARN "Backup failed with exit code $backup_status"
+      fi
 
       if [[ $PRE_SAVE_ON_SCRIPT_FILE ]]; then
-        "$PRE_SAVE_ON_SCRIPT_FILE"
+        "$PRE_SAVE_ON_SCRIPT_FILE" $backup_status
       fi
 
       retry ${RCON_RETRIES} ${RCON_RETRY_INTERVAL} rcon-cli save-on
@@ -659,7 +664,7 @@ while true; do
       trap EXIT
 
       if [[ $POST_BACKUP_SCRIPT_FILE ]]; then
-        "$POST_BACKUP_SCRIPT_FILE"
+        "$POST_BACKUP_SCRIPT_FILE" $backup_status
       fi
 
     else
@@ -673,10 +678,15 @@ while true; do
       "$PRE_BACKUP_SCRIPT_FILE"
     fi
 
-    "${BACKUP_METHOD}" backup
+    backup_status=0
+    "${BACKUP_METHOD}" backup || backup_status=$?
+
+    if [[ $backup_status -ne 0 ]]; then
+      log WARN "Backup failed with exit code $backup_status"
+    fi
 
     if [[ $POST_BACKUP_SCRIPT_FILE ]]; then
-      "$POST_BACKUP_SCRIPT_FILE"
+      "$POST_BACKUP_SCRIPT_FILE" $backup_status
     fi
   fi
 


### PR DESCRIPTION
Closes #135.

This passes the backup utility exit code to the post-backup scripts. In addition, it also `tee`s their output to a temporary log file, and passes that to the script as well.
