### PR TITLE
Add restic backup upload speed limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Use the `RESTIC_ADDITIONAL_TAGS` variable to define a space separated list of ad
 
 By default, the hostname, typically the container/pod's name, will be used as the Restic backup's hostname. That can be overridden by setting `RESTIC_HOSTNAME` 
 
+If you want to limit the restic backup upload speed, you can set the `RESTIC_LIMIT_UPLOAD` variable to a value in KiB/s. For example, `RESTIC_LIMIT_UPLOAD=1024` will limit the upload speed to approximately 1 MiB/s. By default, there is no limit.
+
 You can fine tune the retention cycle of the restic backups using the `PRUNE_RESTIC_RETENTION` variable. Take a look at the [restic documentation](https://restic.readthedocs.io/en/latest/060_forget.html) for details.
 
 > **_EXAMPLE_**  

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -41,6 +41,7 @@ fi
 : "${RESTIC_ADDITIONAL_TAGS=mc_backups}" # Space separated list of restic tags
 : "${RESTIC_HOSTNAME:=$(hostname)}"
 : "${RESTIC_VERBOSE:=false}"
+: "${RESTIC_LIMIT_UPLOAD:=0}"
 : "${XDG_CONFIG_HOME:=/config}" # for rclone's base config path
 : "${ONE_SHOT:=false}"
 : "${TZ:=Etc/UTC}"
@@ -478,6 +479,7 @@ restic() {
     log INFO "Backing up content in ${SRC_DIR} as host ${RESTIC_HOSTNAME}"
     args=(
       --host "${RESTIC_HOSTNAME}"
+      --limit-upload "${RESTIC_LIMIT_UPLOAD}"
     )
     if isDebug || isTrue "$RESTIC_VERBOSE"; then
       args+=(-vv)


### PR DESCRIPTION
A default value of `0` equals unlimited speed: https://github.com/restic/restic/blob/126ad045682838ac20bb3410d369a1650c31d9b0/cmd/restic/global.go#L119

I didn't add an option to limit the download speed because `docker-mc-backup` doesn't support restoring restic backups out of the box.

Relates to #209