### PR TITLE
docs: improve description for RESTIC_RETRY_LOCK variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ By default, the hostname, typically the container/pod's name, will be used as th
 
 If you want to limit the restic backup upload speed, you can set the `RESTIC_LIMIT_UPLOAD` variable to a value in KiB/s. For example, `RESTIC_LIMIT_UPLOAD=1024` will limit the upload speed to approximately 1 MiB/s. By default, there is no limit.
 
-When sharing a restic repository between multiple containers, set RESTIC_RETRY_LOCK (e.g., 5m) to define the maximum time restic will retry acquiring the repository lock before giving up. 
+If multiple containers share the same repository, use `RESTIC_RETRY_LOCK` (e.g., 5m) to define how long Restic should retry acquiring the repository lock before giving up. This helps avoid conflicts during overlapping backup runs by allowing time for other jobs to finish and release the lock.
 
 You can fine tune the retention cycle of the restic backups using the `PRUNE_RESTIC_RETENTION` variable. Take a look at the [restic documentation](https://restic.readthedocs.io/en/latest/060_forget.html) for details.
 


### PR DESCRIPTION
Clarifies the purpose and behavior of the `RESTIC_RETRY_LOCK` variable in the README.

Also fixes a formatting issue where I missed formatting `RESTIC_RETRY_LOCK` as inline code.

Follow-up to #234.
