### PR TITLE
Feature: Cron based backup scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `BACKUP_ON_STARTUP`=true : Set to false to skip first backup on startup.
 - `PAUSE_IF_NO_PLAYERS`=false
 - `PLAYERS_ONLINE_CHECK_INTERVAL`=5m
+- `CRON_SCHEDULE`: disabled unless set, [see below](#cron-scheduling) how to enable
 - `PRUNE_BACKUPS_DAYS`=7
 - `PRUNE_BACKUPS_COUNT`= -disabled unless set (only works with tar/rsync)
 - `PRUNE_RESTIC_RETENTION`=--keep-within 7d
@@ -58,6 +59,31 @@ The `PAUSE_IF_NO_PLAYERS` option lets you pause backups if no players are online
 If `PAUSE_IF_NO_PLAYERS`="true" and there are no players online after a backup is made, then instead of immediately scheduling the next backup, the script will start checking the server's player count every `PLAYERS_ONLINE_CHECK_INTERVAL` (defaults to 5 minutes). Once a player joins the server, the next backup will be scheduled in `BACKUP_INTERVAL`.
 
 `EXCLUDES` is a comma-separated list of glob(3) patterns to exclude from backups. By default excludes all jar files (plugins, server files), logs folder and cache (used by i.e. PaperMC server).
+
+### Cron scheduling
+
+Enable clock based scheduling with Cron by setting `CRON_SCHEDULE` to a value in the format of a [cron expression](https://en.wikipedia.org/wiki/Cron#Cron_expression).
+
+#### Examples
+- `CRON_SCHEDULE`="0 4 * * *" -> backup every day at 4 am
+- `CRON_SCHEDULE`="0 * * * *" -> backup every hour
+- `CRON_SCHEDULE`="0 0 1 * *" -> backup at the 1st day of every month
+
+The time is in UTC timezone by default, but if you want to use your servers local time, you can pass it to the container as seen in the `volumes` section below:
+
+```yaml
+backup:
+  image: itzg/mc-backup
+  restart: unless-stopped
+  environment:
+    CRON_SCHEDULE: "0 4 * * *"
+  volumes:
+    /etc/localtime:/etc/localtime:ro
+    /etc/timezone:/etc/timezone:ro
+```
+
+> **Note**  
+> Setting `CRON_SCHEDULE` overrides other interval based backup triggering and thus these parameters have no effect while it's set: `INITIAL_DELAY`, `BACKUP INTERVAL`, `BACKUP_ON_STARTUP`, `PAUSE_IF_NO_PLAYERS` and `PLAYERS_ONLINE_CHECK_INTERVAL`
 
 ### Backup methods
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `PAUSE_IF_NO_PLAYERS`=false
 - `PLAYERS_ONLINE_CHECK_INTERVAL`=5m
 - `CRON_SCHEDULE`: disabled unless set, [see below](#cron-scheduling) how to enable
+- `BACKUP_UID`: Can be set to user id to run cron schedule as non-root.
 - `PRUNE_BACKUPS_DAYS`=7
 - `PRUNE_BACKUPS_COUNT`= -disabled unless set (only works with tar/rsync)
 - `PRUNE_RESTIC_RETENTION`=--keep-within 7d
@@ -62,6 +63,9 @@ If `PAUSE_IF_NO_PLAYERS`="true" and there are no players online after a backup i
 
 ### Cron scheduling
 
+> [!WARNING]
+> The container must be run with root user to launch `crond`. While you can use `BACKUP_UID` parameter to use non-root user, this is still less secure than running the container as non-root user.
+
 Enable clock based scheduling with Cron by setting `CRON_SCHEDULE` to a value in the format of a [cron expression](https://en.wikipedia.org/wiki/Cron#Cron_expression).
 
 #### Examples
@@ -77,12 +81,15 @@ backup:
   restart: unless-stopped
   environment:
     CRON_SCHEDULE: "0 4 * * *"
+    BACKUP_UID: "1000"
   volumes:
     /etc/localtime:/etc/localtime:ro
     /etc/timezone:/etc/timezone:ro
 ```
 
-> **Note**  
+To run the backups as a non-root user, set `BACKUP_UID` to a user id and the backup processes will be spawned with that user. Service attribute `user` is incompatible with cron scheduling.
+
+> [!NOTE]
 > Setting `CRON_SCHEDULE` overrides other interval based backup triggering and thus these parameters have no effect while it's set: `INITIAL_DELAY`, `BACKUP INTERVAL`, `BACKUP_ON_STARTUP`, `PAUSE_IF_NO_PLAYERS` and `PLAYERS_ONLINE_CHECK_INTERVAL`
 
 ### Backup methods

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Provides a side-car container to back up [itzg/minecraft-server](https://github.
 - `PAUSE_IF_NO_PLAYERS`=false
 - `PLAYERS_ONLINE_CHECK_INTERVAL`=5m
 - `CRON_SCHEDULE`: disabled unless set, [see below](#cron-scheduling) how to enable
-- `BACKUP_UID`: Can be set to user id to run cron schedule as non-root.
+- `CRON_BACKUP_UID`: Can be set to user id to run cron schedule as non-root.
 - `PRUNE_BACKUPS_DAYS`=7
 - `PRUNE_BACKUPS_COUNT`= -disabled unless set (only works with tar/rsync)
 - `PRUNE_RESTIC_RETENTION`=--keep-within 7d
@@ -64,7 +64,7 @@ If `PAUSE_IF_NO_PLAYERS`="true" and there are no players online after a backup i
 ### Cron scheduling
 
 > [!WARNING]
-> The container must be run with root user to launch `crond`. While you can use `BACKUP_UID` parameter to use non-root user, this is still less secure than running the container as non-root user.
+> The container must be run with root user to launch `crond`. While you can use `CRON_BACKUP_UID` parameter to use non-root user, this is still less secure than running the container as non-root user.
 
 Enable clock based scheduling with Cron by setting `CRON_SCHEDULE` to a value in the format of a [cron expression](https://en.wikipedia.org/wiki/Cron#Cron_expression).
 
@@ -81,13 +81,13 @@ backup:
   restart: unless-stopped
   environment:
     CRON_SCHEDULE: "0 4 * * *"
-    BACKUP_UID: "1000"
+    CRON_BACKUP_UID: "1000"
   volumes:
     /etc/localtime:/etc/localtime:ro
     /etc/timezone:/etc/timezone:ro
 ```
 
-To run the backups as a non-root user, set `BACKUP_UID` to a user id and the backup processes will be spawned with that user. Service attribute `user` is incompatible with cron scheduling.
+To run the backups as a non-root user, set `CRON_BACKUP_UID` to a user id and the backup processes will be spawned with that user. Service attribute `user` is incompatible with cron scheduling.
 
 > [!NOTE]
 > Setting `CRON_SCHEDULE` overrides other interval based backup triggering and thus these parameters have no effect while it's set: `INITIAL_DELAY`, `BACKUP INTERVAL`, `BACKUP_ON_STARTUP`, `PAUSE_IF_NO_PLAYERS` and `PLAYERS_ONLINE_CHECK_INTERVAL`

--- a/scripts/bin/backup
+++ b/scripts/bin/backup
@@ -27,7 +27,7 @@ file_env "AWS_SECRET_ACCESS_KEY"
 args=(/opt/entrypoint-demoter --match /backups)
 
 # if a cron schedule is set, configure and run crond in foreground
-if [[ -v CRON_SCHEDULE ]]; then
+if [[ -v CRON_SCHEDULE && "$1" == "loop" ]]; then
   if [[ ! $EUID -eq 0 ]]; then
     echo "Cron scheduling requires root user, use BACKUP_UID to run backup as non-root user"
     exit 1

--- a/scripts/bin/backup
+++ b/scripts/bin/backup
@@ -28,7 +28,21 @@ args=(/opt/entrypoint-demoter --match /backups)
 
 # if a cron schedule is set, configure and run crond in foreground
 if [[ -v CRON_SCHEDULE ]]; then
-  "${args[@]}" echo "$CRON_SCHEDULE export ONE_SHOT=true; /opt/backup-loop.sh" | crontab -
+  if [[ ! $EUID -eq 0 ]]; then
+    echo "Cron scheduling requires root user, use BACKUP_UID to run backup as non-root user"
+    exit 1
+  fi
+
+  if [[ -v BACKUP_UID ]]; then
+    # add 'backup' user if not already added
+    id -u backup &>/dev/null || adduser -DHu $BACKUP_UID backup
+    # non-root user cron job
+    echo "$CRON_SCHEDULE export ONE_SHOT=true; /opt/backup-loop.sh" | crontab -u backup -
+  else
+    # root cron job, but still uses entrypoint-demoter
+    echo "$CRON_SCHEDULE export ONE_SHOT=true; ${args[@]} /opt/backup-loop.sh" | crontab -
+  fi
+
   exec crond -f -L /dev/stdout
 fi
 

--- a/scripts/bin/backup
+++ b/scripts/bin/backup
@@ -26,6 +26,12 @@ file_env "AWS_SECRET_ACCESS_KEY"
 
 args=(/opt/entrypoint-demoter --match /backups)
 
+# if a cron schedule is set, configure and run crond in foreground
+if [[ -v CRON_SCHEDULE ]]; then
+  "${args[@]}" echo "$CRON_SCHEDULE export ONE_SHOT=true; /opt/backup-loop.sh" | crontab -
+  exec crond -f -L /dev/stdout
+fi
+
 case "$1" in
   now)
     ONE_SHOT=true exec "${args[@]}" /opt/backup-loop.sh ;;

--- a/scripts/bin/backup
+++ b/scripts/bin/backup
@@ -29,13 +29,13 @@ args=(/opt/entrypoint-demoter --match /backups)
 # if a cron schedule is set, configure and run crond in foreground
 if [[ -v CRON_SCHEDULE && "$1" == "loop" ]]; then
   if [[ ! $EUID -eq 0 ]]; then
-    echo "Cron scheduling requires root user, use BACKUP_UID to run backup as non-root user"
+    echo "Cron scheduling requires root user, use CRON_BACKUP_UID to run backup as non-root user"
     exit 1
   fi
 
-  if [[ -v BACKUP_UID ]]; then
+  if [[ -v CRON_BACKUP_UID ]]; then
     # add 'backup' user if not already added
-    id -u backup &>/dev/null || adduser -DHu $BACKUP_UID backup
+    id -u backup &>/dev/null || adduser -DHu $CRON_BACKUP_UID backup
     # non-root user cron job
     echo "$CRON_SCHEDULE export ONE_SHOT=true; /opt/backup-loop.sh" | crontab -u backup -
   else


### PR DESCRIPTION
This adds a new optional environment variable `CRON_SCHEDULE` that is unset by default, but can be set to a cron expression. When set, this expression is used to configure a cron job that runs the backup script in one shot mode at the times specified. `crond` is already included in the image via busybox and it's run as a foreground process with log redirected to `stdout`.

This allows running backups at set times instead of intervals relative to the starting of the container and configured initial delay.

Fixes #76, fixes #156