### PR TITLE
Fix prune function call condition

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -726,7 +726,7 @@ while true; do
 
   rm "$backup_log"
 
-  if (( PRUNE_BACKUPS_DAYS > 0 )); then
+  if (( PRUNE_BACKUPS_DAYS > 0 )) || [[ -n "$PRUNE_BACKUPS_COUNT" ]]; then
     "${BACKUP_METHOD}" prune
   fi
 


### PR DESCRIPTION
https://github.com/itzg/docker-mc-backup/issues/243

This allow the usage of PRUNE_BACKUPS_COUNT without the need of PRUNE_BACKUPS_DAYS to a specific value (PRUNE_BACKUPS_DAYS could then be 0 or -1)