### PR TITLE
Realtime restic error output

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -452,7 +452,11 @@ restic() {
       _unlock
       log INFO "Checking repo integrity"
       _check
-    elif <<<"${output}" grep -q '^Is there a repository at the following location?$'; then
+    elif <<<"${output}" grep -q 'Fatal: unable to open config file: Stat: 400 Bad Request$'; then
+      <<<"${output}" log ERROR
+      log ERROR "Unable to open config file. Please check restic configuration"
+      return 1
+    elif <<<"${output}" grep -q 'Is there a repository at the following location?$'; then
       log INFO "Initializing new restic repository..."
       command restic init | log INFO
     elif <<<"${output}" grep -q 'wrong password'; then


### PR DESCRIPTION
Resolves https://github.com/itzg/docker-mc-backup/issues/252

Restic with an S3 repository can take up to 15 minutes while retrying to connect to an S3 bucket (for example, when AWS_DEFAULT_REGION set to invalid value). The log is **completely empty** while Restic is retrying, which makes it look as if the backup script is stuck.

The S3 availability check fails during the first request to S3, so I added some output redirection to the stdout of the backup script. Unfortunately, I didn't find a way to reuse existing `log` functionality, so I added a simple prefix `restic cat config` for clarity. It is completely optional, but without this prefix it's unclear what the errors means.

Example log output with this patch:

```
$ docker-compose up backups
[+] Running 1/1
 ✔ Container minecraft-server-vanilla-winter-2025-backups-1  Created                             0.0s
Attaching to backups-1
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 1.072411439s: Stat: 400 Bad Request
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 1.597222708s: Stat: 400 Bad Request
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 5.504658033s: Stat: 400 Bad Request
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 5.604453619s: Stat: 400 Bad Request
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 16.303520869s: Stat: 400 Bad Request
backups-1  | restic cat config: Stat(<config/>) returned error, retrying after 23.496983485s: Stat: 400 Bad Request
Gracefully stopping... (press Ctrl+C again to force)
```