### PR TITLE
fix restic unlock success detection

### DIFF
--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -431,15 +431,21 @@ restic() {
   }
 
   _unlock() {
-  if ! [ -z "${output=$(command restic list locks 2>&1)}" ];then
-     log WARN "Confirmed stale lock on repo, unlocking..."
-     if [[ unlock=$(command restic unlock 2>&1) == *"success"* ]]; then
+    if output="$(command restic list locks 2>&1)" && [ -n "${output}" ]; then
+      log WARN "Confirmed stale lock on repo, unlocking..."
+      if unlock_output="$(command restic unlock 2>&1)"; then
+        if [ -n "${unlock_output}" ]; then
+          <<<"${unlock_output}" log INFO
+        fi
         log INFO "Successfully unlocked the repo"
-     else
+      else
+        if [ -n "${unlock_output}" ]; then
+          <<<"${unlock_output}" log ERROR
+        fi
         log ERROR "Unable to unlock the repo. Is there another process running?"
         return 1
-     fi
-  fi
+      fi
+    fi
   }
 
   _check() {


### PR DESCRIPTION
## Summary
- rely on `restic unlock` exit status instead of matching `success` in stdout
- log `restic unlock` output when present
- avoid false unlock failures in scheduled restic backups

## Context
In a `docker-mc-backup` container using `BACKUP_METHOD=restic` with an S3-compatible `RESTIC_REPOSITORY`, the scheduled backup path repeatedly logged:

```text
INFO Repository already initialized
INFO Checking for stale locks
WARN Confirmed stale lock on repo, unlocking...
ERROR Unable to unlock the repo. Is there another process running?
```

However, in the same container:
- `backup now` succeeded
- `restic list locks` returned no output and exited `0` immediately after the scheduled failure
- `restic unlock -v` returned no output and exited `0` immediately after the scheduled failure

The existing logic requires `restic unlock` stdout to contain `success`, which can misclassify a successful unlock when the command exits `0` without printing that string.