### PR TITLE
fix: use RESTIC_HOST for restic snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ At least one of the `RESTIC_PASSWORD*` variables need to be defined, along with 
 
 Use the `RESTIC_ADDITIONAL_TAGS` variable to define a space separated list of additional restic tags. The backup will always be tagged with the value of `BACKUP_NAME`. e.g.: `RESTIC_ADDITIONAL_TAGS=mc_backups foo bar` will tag your backup with `foo`, `bar`, `mc_backups` and the value of `BACKUP_NAME`.
 
-By default, the hostname, typically the container/pod's name, will be used as the Restic backup's hostname. That can be overridden by setting `RESTIC_HOSTNAME` 
+By default, the hostname, typically the container/pod's name, will be used as the Restic backup's hostname. That can be overridden by setting `RESTIC_HOST`. The legacy `RESTIC_HOSTNAME` variable is also supported when `RESTIC_HOST` is not set.
 
 If you want to limit the restic backup upload speed, you can set the `RESTIC_LIMIT_UPLOAD` variable to a value in KiB/s. For example, `RESTIC_LIMIT_UPLOAD=1024` will limit the upload speed to approximately 1 MiB/s. By default, there is no limit.
 

--- a/scripts/opt/backup-loop.sh
+++ b/scripts/opt/backup-loop.sh
@@ -42,7 +42,7 @@ fi
 : "${EXCLUDES_FILE:=}" # Path to file containing list of glob(3) patterns
 : "${LINK_LATEST:=false}"
 : "${RESTIC_ADDITIONAL_TAGS=mc_backups}" # Space separated list of restic tags
-: "${RESTIC_HOSTNAME:=$(hostname)}"
+: "${RESTIC_HOST:=${RESTIC_HOSTNAME:-$(hostname)}}"
 : "${RESTIC_VERBOSE:=false}"
 : "${RESTIC_LIMIT_UPLOAD:=0}"
 : "${RESTIC_CAT_CONFIG_TIMEOUT:=10s}"
@@ -69,6 +69,7 @@ export XDG_CONFIG_HOME
 export SRC_DIR
 export DEST_DIR
 export BACKUP_NAME
+export RESTIC_HOST
 
 resolve_backup_name() {
   if ! isTrue "$NAME_WITH_VERSION"; then
@@ -459,7 +460,7 @@ restic() {
 
   _delete_old_backups() {
     # shellcheck disable=SC2086
-    command restic --retry-lock "${RESTIC_RETRY_LOCK}" forget --host "${RESTIC_HOSTNAME}" --tag "${restic_tags_filter}" ${PRUNE_RESTIC_RETENTION} "${@}"
+    command restic --retry-lock "${RESTIC_RETRY_LOCK}" forget --tag "${restic_tags_filter}" ${PRUNE_RESTIC_RETENTION} "${@}"
   }
 
   _unlock() {
@@ -553,10 +554,9 @@ restic() {
       exit 1
     fi
 
-    log INFO "Backing up content in ${SRC_DIR} as host ${RESTIC_HOSTNAME}"
+    log INFO "Backing up content in ${SRC_DIR} as host ${RESTIC_HOST}"
     args=(
       --retry-lock "${RESTIC_RETRY_LOCK}"
-      --host "${RESTIC_HOSTNAME}"
       --limit-upload "${RESTIC_LIMIT_UPLOAD}"
     )
     if isDebug || isTrue "$RESTIC_VERBOSE"; then

--- a/tests/test.simple.restic.sh
+++ b/tests/test.simple.restic.sh
@@ -18,6 +18,7 @@ trap 'sudo rm -rf "${TMP_DIR}"' EXIT
 : "${EXCLUDES:='*.jar,exclude_dir'}"
 : "${RCON_PATH:=/usr/bin/rcon-cli}"
 : "${RESTIC_PASSWORD:=1234}"
+: "${RESTIC_HOSTNAME:=legacy-restic-host}"
 
 export LOCAL_SRC_DIR="${TMP_DIR}/${SRC_DIR}"
 export LOCAL_DEST_DIR="${TMP_DIR}/${DEST_DIR}"
@@ -33,6 +34,7 @@ export INITIAL_DELAY
 export EXCLUDES
 export RCON_PATH
 export RESTIC_PASSWORD
+export RESTIC_HOSTNAME
 
 timeout --kill-after=20 50 docker run --rm \
     --env SRC_DIR \
@@ -42,6 +44,7 @@ timeout --kill-after=20 50 docker run --rm \
     --env PRUNE_BACKUPS_DAYS \
     --env RESTIC_REPOSITORY \
     --env RESTIC_PASSWORD \
+    --env RESTIC_HOSTNAME \
     --env DEBUG \
     --env BACKUP_METHOD=restic \
     --mount "type=bind,src=${LOCAL_SRC_DIR},dst=${SRC_DIR}" \
@@ -59,5 +62,6 @@ restic() {
       localhost:5000/itzg/mc-backup:latest "${@}"
 }
 restic ls latest
+test "$(restic snapshots --host "${RESTIC_HOSTNAME}" --json | jq length)" -eq 1
 ! restic ls latest 2>/dev/null | grep -q "exclude_"
 [ 4 -eq "$(restic ls latest 2>/dev/null | grep -c "backup_me")" ]


### PR DESCRIPTION
## Summary

- I switched the backup script to Restic's native `RESTIC_HOST` environment variable and removed redundant `--host` arguments.
- I kept `RESTIC_HOSTNAME` as a backward-compatible fallback when `RESTIC_HOST` is not set.
- I updated the Restic integration test to verify that the legacy variable still selects the snapshot host, and documented the preferred variable.

## Validation

- `bash -n scripts/opt/backup-loop.sh tests/test.simple.restic.sh`
- ad-hoc one-shot mock-Restic harness covering native-variable precedence, legacy fallback, environment propagation, and absence of `--host`
- `git diff --check origin/master...HEAD`

I deferred the Docker image build and full Restic integration test to CI because the repository workflow performs a full container build before running it.

Fixes #301
